### PR TITLE
remove hard coded topics and get from job info

### DIFF
--- a/abc_utils.py
+++ b/abc_utils.py
@@ -7,7 +7,6 @@ from typing import List
 from urllib.error import HTTPError
 
 import requests
-from cachetools import TTLCache
 from fastapi_okta.okta_utils import get_authentication_token, generate_headers
 
 blue_api_base_url = os.environ.get('ABC_API_SERVER', "literature-rest.alliancegenome.org")
@@ -15,16 +14,6 @@ blue_api_base_url = os.environ.get('ABC_API_SERVER', "literature-rest.alliancege
 logger = logging.getLogger(__name__)
 
 cache = {}
-
-job_category_topic_map = {
-    "catalytic_activity": "ATP:0000061",
-    "disease": "ATP:0000152",
-    "expression": "ATP:0000010",
-    "interaction": "ATP:0000068",
-    "physical_interaction": "ATP:0000069",
-    "RNAi": "ATP:0000082",
-    "antibody": "ATP:0000096"
-}
 
 
 def get_mod_species_map():

--- a/agr_document_classifier.py
+++ b/agr_document_classifier.py
@@ -377,7 +377,7 @@ def parse_arguments():
 
 
 def load_jobs_to_classify():
-    mod_datatype_jobs = defaultdict(list)
+    mod_topic_jobs = defaultdict(list)
     limit = 1000
     offset = 0
     jobs_already_added = set()
@@ -386,22 +386,22 @@ def load_jobs_to_classify():
     while all_jobs := get_jobs_to_classify(limit, offset):
         for job in all_jobs:
             reference_id = job["reference_id"]
-            datatype = job["job_name"].replace("_classification_job", "")
+            # datatype = job["job_name"].replace("_classification_job", "")
             mod_id = job["mod_id"]
-            if (mod_id, datatype, reference_id) not in jobs_already_added:
-                mod_datatype_jobs[(mod_id, datatype)].append(job)
-                jobs_already_added.add((mod_id, datatype, reference_id))
+            topic = job["topic_id"]
+            if (mod_id, topic, reference_id) not in jobs_already_added:
+                mod_topic_jobs[(mod_id, topic)].append(job)
+                jobs_already_added.add((mod_id, topic, reference_id))
         offset += limit
 
     logger.info("Finished loading jobs to classify from ABC ...")
-    return mod_datatype_jobs
+    return mod_topic_jobs
 
 
-def process_classification_jobs(mod_id, datatype, jobs, embedding_model):
+def process_classification_jobs(mod_id, topic, jobs, embedding_model):
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
-    datatype = datatype.replace(" ", "_")
+    datatype = topic.replace(":", "_")
     tet_source_id = get_tet_source_id(mod_abbreviation=mod_abbr)
-    topic = job_category_topic_map[datatype]
     classifier_file_path = f"/data/agr_document_classifier/{mod_abbr}_{datatype}_classifier.joblib"
     try:
         load_classifier(mod_abbr, topic, classifier_file_path)
@@ -535,11 +535,11 @@ def train_mode(args):
 
 
 def classify_mode(args):
-    mod_datatype_jobs = load_jobs_to_classify()
+    mod_topic_jobs = load_jobs_to_classify()
     embedding_model = load_embedding_model(args.embedding_model_path)
 
-    for (mod_id, datatype), jobs in mod_datatype_jobs.items():
-        process_classification_jobs(mod_id, datatype, jobs, embedding_model)
+    for (mod_id, topic), jobs in mod_topic_jobs.items():
+        process_classification_jobs(mod_id, topic, jobs, embedding_model)
 
 
 def main():


### PR DESCRIPTION
datatype variable ( name of the classification i.e. "catalytic_activity") removed and replaced with the topic_id (example here would be "ATP:0000061").
When downloading the model this now gets stored to a different path.
So previous we had (for example)
   /data/agr_document_classifier/FB_catalytic_activity_classifier.joblib
would now be
  /data/agr_document_classifier/FB_ATP_0000061_classifier.joblib

Replaced ":" with '_' in the topic_id incase that did funky stuff in directory names on some systems.