### PR TITLE
feat: batch processing and error handling for priority classifier

### DIFF
--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -513,12 +513,16 @@ def send_priority_results(files_loaded, classifications, conf_scores,
     logger.info("Finished processing batch of %s jobs.", len(files_loaded))
 
 
-def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embedding_model_path: str,
-                            ref_curie_to_mod_curie: dict = None, mod_topic_jobs: dict = None):
+def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str,
+                            embedding_model_path: str,
+                            ref_curie_to_mod_curie: dict = None):
 
     # Load classifier and embeddings
-    classifier_model_path = f"{root_data_path}training/{mod_abbr}_{topic.replace(':', '_')}_classifier.joblib"
-    download_abc_model(mod_abbreviation=mod_abbr, topic=topic, output_path=classifier_model_path,
+    classifier_model_path = (
+        f"{root_data_path}training/{mod_abbr}"
+        f"_{topic.replace(':', '_')}_classifier.joblib")
+    download_abc_model(mod_abbreviation=mod_abbr, topic=topic,
+                       output_path=classifier_model_path,
                        task_type="biocuration_pretriage_priority_classification")
     logger.info(f"Priority classifier model downloaded for mod: {mod_abbr}, topic: {topic}.")
 
@@ -533,10 +537,6 @@ def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embeddin
 
     label_mapping = {0: "priority_1", 1: "priority_2", 2: "priority_3"}
     results_file = os.path.join(output_dir, "classification_results.csv")
-    ref_curie_job_map = {}
-    for (_mod_id, _topic), jobs in mod_topic_jobs.items():
-        for job in jobs:
-            ref_curie_job_map[job["reference_curie"]] = job
     with open(results_file, mode='w', newline='', encoding='utf-8') as outcsv:
         writer = csv.writer(outcsv)
         headers = ['ReferenceID', 'Classification', 'ConfidenceScore', 'ValidEmbedding']
@@ -544,21 +544,19 @@ def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embeddin
             headers.insert(1, 'MOD_ReferenceID')
         writer.writerow(headers)
 
-        for path, label, score, valid in zip(files_loaded, classifications, conf_scores, valid_embeddings):
+        for path, label, score, valid in zip(files_loaded, classifications,
+                                             conf_scores, valid_embeddings):
             reference_id = Path(path).stem.replace('_', ':')
-            py_score = float(score)  # ensure native float
+            py_score = float(score)
             row = [reference_id]
             if ref_curie_to_mod_curie:
                 row.append(ref_curie_to_mod_curie.get(reference_id, ''))
-            row.extend([label_mapping.get(label, 'unknown'), round(py_score, 4), bool(valid)])
+            row.extend([label_mapping.get(label, 'unknown'),
+                        round(py_score, 4), bool(valid)])
             writer.writerow(row)
             priority_name = label_mapping.get(label, 'unknown')
-            ref_curie = reference_id
-            set_indexing_priority(ref_curie, mod_abbr, priority_name, round(py_score, 2))
-            if valid:
-                set_job_success(ref_curie_job_map[reference_id])
-            else:
-                set_job_failure(ref_curie_job_map[reference_id])
+            set_indexing_priority(
+                reference_id, mod_abbr, priority_name, round(py_score, 2))
 
     logger.info(f"Classification complete. Results saved to {results_file}")
 

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -11,6 +11,7 @@ import os.path
 import shutil
 import sys
 import csv
+from types import SimpleNamespace
 
 from pathlib import Path
 from typing import Tuple, List
@@ -397,7 +398,9 @@ def classify_need_prioritization_papers(mod_abbr: str, topic: str, embedding_mod
     output_dir = f"{root_data_path}new_to_classify"
     shutil.rmtree(output_dir, ignore_errors=True)
     os.makedirs(output_dir, exist_ok=True)
-    mod_topic_jobs = load_all_jobs(job_label="indexing_priority")
+    mod_topic_jobs = load_all_jobs(job_label="indexing_priority",
+                                   args=SimpleNamespace(mod_abbreviation=mod_abbr, topic=topic,
+                                                        reference_curie=None))
     # Fetch all “need prioritization” papers into output_dir
     download_bib_data_for_need_prioritization_references(output_dir, mod_abbr, mod_topic_jobs)
 

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -395,20 +395,122 @@ def classify_from_csv_file(csv_path: str, mod_abbr: str, topic: str, embedding_m
 
 
 def classify_need_prioritization_papers(mod_abbr: str, topic: str, embedding_model_path: str):
+    mod_topic_jobs = load_all_jobs(
+        job_label="indexing_priority",
+        args=SimpleNamespace(mod_abbreviation=mod_abbr, topic=topic,
+                             reference_curie=None))
+    if not mod_topic_jobs:
+        logger.info("No papers to classify for MOD '%s'.", mod_abbr)
+        return
+
+    embedding_model = load_embedding_model(model_path=embedding_model_path)
+    failed_processes = []
+    for (mod_id, topic_id), jobs in mod_topic_jobs.items():
+        try:
+            process_priority_classification_jobs(
+                mod_id, topic_id, jobs, embedding_model)
+        except Exception as e:
+            logger.error("Error processing priority jobs for '%s', mod %s.",
+                         topic_id, mod_id)
+            formatted_traceback = traceback.format_tb(e.__traceback__)
+            failed_processes.append({
+                "topic": topic_id,
+                "mod_abbreviation": mod_id,
+                "exception": str(e),
+                "trace": "".join(
+                    f"{line}<br>" for line in formatted_traceback)
+            })
+
+    if failed_processes:
+        subject = "Failed processing of priority classification jobs"
+        message = "<h>The following jobs failed to process:</h><br><br>\n\n"
+        for fp in failed_processes:
+            message += (
+                f"Topic: {fp['topic']}  mod_id:{fp['mod_abbreviation']}<br>\n"
+                f"Exception: {fp['exception']}<br>\n"
+                f"Stacktrace: {fp['trace']}<br><br>\n\n")
+        send_report(subject, message)
+        sys.exit(-1)
+
+
+def process_priority_classification_jobs(mod_id, topic, jobs, embedding_model):
+    mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
     output_dir = f"{root_data_path}new_to_classify"
+    classifier_model_path = (
+        f"{root_data_path}training/{mod_abbr}"
+        f"_{topic.replace(':', '_')}_classifier.joblib")
+    try:
+        download_abc_model(
+            mod_abbreviation=mod_abbr, topic=topic,
+            output_path=classifier_model_path,
+            task_type="biocuration_pretriage_priority_classification")
+        logger.info(
+            "Priority classifier model downloaded for mod: %s, topic: %s.",
+            mod_abbr, topic)
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 404:
+            logger.warning(
+                "Priority classifier model not found for mod: %s, "
+                "topic: %s. Skipping.", mod_abbr, topic)
+            return
+        raise
+
+    classifier_model = joblib.load(classifier_model_path)
+    classification_batch_size = int(
+        os.environ.get("CLASSIFICATION_BATCH_SIZE", 1000))
+    jobs_to_process = copy.deepcopy(jobs)
+    while jobs_to_process:
+        job_batch = jobs_to_process[:classification_batch_size]
+        jobs_to_process = jobs_to_process[classification_batch_size:]
+        logger.info(
+            "Processing a batch of %s jobs. Jobs remaining to process: %s",
+            len(job_batch), len(jobs_to_process))
+        process_priority_job_batch(
+            job_batch, output_dir, topic, mod_abbr,
+            embedding_model, classifier_model)
+
+
+def process_priority_job_batch(job_batch, output_dir, topic, mod_abbr,
+                               embedding_model, classifier_model):
+    ref_curie_job_map = {job["reference_curie"]: job for job in job_batch}
+
+    # Clean and prepare directory
     shutil.rmtree(output_dir, ignore_errors=True)
     os.makedirs(output_dir, exist_ok=True)
-    mod_topic_jobs = load_all_jobs(job_label="indexing_priority",
-                                   args=SimpleNamespace(mod_abbreviation=mod_abbr, topic=topic,
-                                                        reference_curie=None))
-    # Fetch all “need prioritization” papers into output_dir
-    download_bib_data_for_need_prioritization_references(output_dir, mod_abbr, mod_topic_jobs)
 
-    # Only proceed if at least one file was downloaded
-    if os.listdir(output_dir):
-        set_priority_for_papers(output_dir, topic, mod_abbr, embedding_model_path, mod_topic_jobs)
-    else:
-        logger.info(f"No papers to classify for MOD '{mod_abbr}'.")
+    # Download bib data for this batch
+    download_bib_data_for_need_prioritization_references(
+        output_dir, mod_abbr, {(mod_abbr, topic): job_batch})
+
+    if not os.listdir(output_dir):
+        logger.info("No papers downloaded in this batch for MOD '%s'.",
+                    mod_abbr)
+        return
+
+    files_loaded, classifications, conf_scores, valid_embeddings = (
+        classify_documents(
+            input_docs_dir=output_dir,
+            embedding_model=embedding_model,
+            classifier_model=classifier_model))
+
+    send_priority_results(files_loaded, classifications, conf_scores,
+                          valid_embeddings, ref_curie_job_map, mod_abbr)
+
+
+def send_priority_results(files_loaded, classifications, conf_scores,
+                          valid_embeddings, ref_curie_job_map, mod_abbr):
+    label_mapping = {0: "priority_1", 1: "priority_2", 2: "priority_3"}
+    for path, label, score, valid in zip(files_loaded, classifications,
+                                         conf_scores, valid_embeddings):
+        reference_id = Path(path).stem.replace("_", ":")
+        priority_name = label_mapping.get(label, "unknown")
+        set_indexing_priority(reference_id, mod_abbr, priority_name,
+                              round(float(score), 2))
+        if valid:
+            set_job_success(ref_curie_job_map[reference_id])
+        else:
+            set_job_failure(ref_curie_job_map[reference_id])
+    logger.info("Finished processing batch of %s jobs.", len(files_loaded))
 
 
 def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embedding_model_path: str,

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -397,18 +397,19 @@ def classify_need_prioritization_papers(mod_abbr: str, topic: str, embedding_mod
     output_dir = f"{root_data_path}new_to_classify"
     shutil.rmtree(output_dir, ignore_errors=True)
     os.makedirs(output_dir, exist_ok=True)
-
+    mod_topic_jobs = load_all_jobs(job_label="indexing_priority")
     # Fetch all “need prioritization” papers into output_dir
-    download_bib_data_for_need_prioritization_references(output_dir, mod_abbr)
+    download_bib_data_for_need_prioritization_references(output_dir, mod_abbr, mod_topic_jobs)
 
     # Only proceed if at least one file was downloaded
     if os.listdir(output_dir):
-        set_priority_for_papers(output_dir, topic, mod_abbr, embedding_model_path)
+        set_priority_for_papers(output_dir, topic, mod_abbr, embedding_model_path, mod_topic_jobs)
     else:
         logger.info(f"No papers to classify for MOD '{mod_abbr}'.")
 
 
-def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embedding_model_path: str, ref_curie_to_mod_curie: dict = None):
+def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embedding_model_path: str,
+                            ref_curie_to_mod_curie: dict = None, mod_topic_jobs: dict = None):
 
     # Load classifier and embeddings
     classifier_model_path = f"{root_data_path}training/{mod_abbr}_{topic.replace(':', '_')}_classifier.joblib"
@@ -427,6 +428,10 @@ def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embeddin
 
     label_mapping = {0: "priority_1", 1: "priority_2", 2: "priority_3"}
     results_file = os.path.join(output_dir, "classification_results.csv")
+    ref_curie_job_map = {}
+    for (mod_id, topic), jobs in mod_topic_jobs.items():
+        for job in jobs:
+            ref_curie_job_map[job["reference_curie"]] = job
     with open(results_file, mode='w', newline='', encoding='utf-8') as outcsv:
         writer = csv.writer(outcsv)
         headers = ['ReferenceID', 'Classification', 'ConfidenceScore', 'ValidEmbedding']
@@ -445,6 +450,10 @@ def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embeddin
             priority_name = label_mapping.get(label, 'unknown')
             ref_curie = reference_id
             set_indexing_priority(ref_curie, mod_abbr, priority_name, round(py_score, 2))
+            if valid:
+                set_job_success(ref_curie_job_map[reference_id])
+            else:
+                set_job_failure(ref_curie_job_map[reference_id])
 
     logger.info(f"Classification complete. Results saved to {results_file}")
 

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -432,7 +432,7 @@ def set_priority_for_papers(output_dir: str, topic: str, mod_abbr: str, embeddin
     label_mapping = {0: "priority_1", 1: "priority_2", 2: "priority_3"}
     results_file = os.path.join(output_dir, "classification_results.csv")
     ref_curie_job_map = {}
-    for (mod_id, topic), jobs in mod_topic_jobs.items():
+    for (_mod_id, _topic), jobs in mod_topic_jobs.items():
         for job in jobs:
             ref_curie_job_map[job["reference_curie"]] = job
     with open(results_file, mode='w', newline='', encoding='utf-8') as outcsv:

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -1,4 +1,3 @@
-import html
 import io
 import json
 import logging
@@ -552,7 +551,7 @@ def download_main_pdf(agr_curie, mod_abbreviation, file_name, output_dir):
 def download_bib_data_for_need_prioritization_references(output_dir: str, mod_abbreviation, mod_topic_jobs):
     logger.info("Started retrieving bib data")
     os.makedirs(output_dir, exist_ok=True)
-    for (mod_id, topic), jobs in mod_topic_jobs.items():
+    for (_mod_id, _topic), jobs in mod_topic_jobs.items():
         for job in jobs:
             try:
                 reference_curie = job['reference_curie']
@@ -560,9 +559,9 @@ def download_bib_data_for_need_prioritization_references(output_dir: str, mod_ab
                 with open(os.path.join(output_dir, reference_curie + ".txt"), "w") as out_file:
                     out_file.write(f"title|{title}\nabstract|{abstract}\n")
                 logger.info(f"{reference_curie}: the txt file is generated.")
-            except requests.exceptions.RequestException as e:
+            except requests.exceptions.RequestException:
                 set_job_failure(job)
-            except HTTPError as http_e:
+            except HTTPError:
                 set_job_failure(job)
 
 

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -549,26 +549,39 @@ def download_main_pdf(agr_curie, mod_abbreviation, file_name, output_dir):
         logger.error(e)
 
 
-def download_bib_data_for_need_prioritization_references(output_dir: str, mod_abbreviation):
+def download_bib_data_for_need_prioritization_references(output_dir: str, mod_abbreviation, mod_topic_jobs):
     logger.info("Started retrieving bib data")
     os.makedirs(output_dir, exist_ok=True)
-    url = f"{blue_api_base_url}/sort/need_prioritization?mod_abbreviation={mod_abbreviation}"
-    token = get_authentication_token()
-    headers = generate_headers(token)
-    try:
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            for x in response.json():
-                reference_curie = x['curie']
-                title = html.unescape(x['title'] or "")
-                abstract = html.unescape(x['abstract'] or "")
+    for (mod_id, topic), jobs in mod_topic_jobs.items():
+        for job in jobs:
+            try:
+                reference_curie = job['reference_curie']
+                title, abstract = get_reference_title_and_abstract(reference_curie)
                 with open(os.path.join(output_dir, reference_curie + ".txt"), "w") as out_file:
                     out_file.write(f"title|{title}\nabstract|{abstract}\n")
                 logger.info(f"{reference_curie}: the txt file is generated.")
+            except requests.exceptions.RequestException as e:
+                set_job_failure(job)
+            except HTTPError as http_e:
+                set_job_failure(job)
+
+
+def get_reference_title_and_abstract(reference_curie):
+    logger.info("Started retrieving title and abstract for reference")
+    url = f"{blue_api_base_url}/reference/{reference_curie}"
+    token = get_authentication_token()
+    headers = generate_headers(token)
+    try:
+        response = requests.request("GET", url, headers=headers)
+        if response.status_code == 200:
+            content = response.json()
+            return content.get("title", None), content.get("abstract", None)
         else:
-            logger.info(f"Bib data not found for {url}: status code {response.status_code}")
+            logger.info(f"reference data not found for {url}: status code {response.status_code}")
+            raise HTTPError(f"reference data not found for {url}: status code {response.status_code}")
     except requests.exceptions.RequestException as e:
         logger.info(f"Error occurred for accessing/retrieving bib data from {url}: error={e}")
+        raise
 
 
 def download_bib_data_for_references(reference_curies: List[str], output_dir: str, mod_abbreviation):

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -574,7 +574,7 @@ def get_reference_title_and_abstract(reference_curie):
         response = requests.request("GET", url, headers=headers)
         if response.status_code == 200:
             content = response.json()
-            return content.get("title", None), content.get("abstract", None)
+            return content.get("title") or "", content.get("abstract") or ""
         else:
             logger.info(f"reference data not found for {url}: status code {response.status_code}")
             raise HTTPError(f"reference data not found for {url}: status code {response.status_code}")

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -802,14 +802,14 @@ def map_priority_name_to_atpid(priority_name):
 def set_indexing_priority(ref_curie, mod_abbr, priority_name, confidence_score):
     priority_atp = map_priority_name_to_atpid(priority_name)
     base = blue_api_base_url.rstrip("/")
-    indexing_url = f"{base}/indexing_priority/set_priority"
+    indexing_url = f"{base}/indexing_priority/"
     token = get_authentication_token()
     headers = generate_headers(token)
 
     payload = {
         "reference_curie": ref_curie,
         "mod_abbreviation": mod_abbr,
-        "indexing_priority": priority_atp,
+        "predicted_indexing_priority": priority_atp,
         "confidence_score": float(confidence_score) if confidence_score is not None else 0.0,
     }
 


### PR DESCRIPTION
## Summary
- Migrate away from custom API endpoints (`sort/need_prioritization` and `indexing_priority/set_priority`) to standard job functions (`load_all_jobs` / `get_jobs_batch` with `indexing_priority` job label) for loading and processing references that need prioritization
- Use the `indexing_priority/` create endpoint with `predicted_indexing_priority` field instead of the deprecated `indexing_priority/set_priority` endpoint with `indexing_priority` field
- Add batch processing for priority classification jobs (configurable via `CLASSIFICATION_BATCH_SIZE` env var, default 1000) instead of classifying all articles at once
- Keep jobs separated by (mod, topic) groups, mirroring the document classifier pattern, to support future additional priority classifiers
- Add per-(mod, topic) error handling with failure reporting via `send_report`
- Fix flake8 errors: unused `html` import, unused loop variables, unused exception bindings

## Test plan
- [x] Tested locally on laptop
- [ ] Needs manual deployment to GoCD when API changes are deployed to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)