### PR TITLE
Fix jobs handling for pre-indexing classification

### DIFF
--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -504,9 +504,12 @@ def send_priority_results(files_loaded, classifications, conf_scores,
                                          conf_scores, valid_embeddings):
         reference_id = Path(path).stem.replace("_", ":")
         priority_name = label_mapping.get(label, "unknown")
-        set_indexing_priority(reference_id, mod_abbr, priority_name,
-                              round(float(score), 2))
         if valid:
+            priority_set = set_indexing_priority(reference_id, mod_abbr, priority_name,
+                                                 round(float(score), 2))
+        else:
+            priority_set = False
+        if priority_set:
             set_job_success(ref_curie_job_map[reference_id])
         else:
             set_job_failure(ref_curie_job_map[reference_id])

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -827,7 +827,7 @@ def set_indexing_priority(ref_curie, mod_abbr, priority_name, confidence_score):
 
     try:
         resp = requests.post(indexing_url, json=_jsonable(payload), headers=headers, timeout=30)
-        if resp.status_code == 200:
+        if resp.status_code in [200, 201]:
             logger.info(f"{ref_curie} is successfully set to {priority_name}")
             return True
 


### PR DESCRIPTION
## Summary
- Only call `set_indexing_priority` when the embedding is valid, and track its return value to correctly mark jobs as success/failure
- Accept HTTP 201 (in addition to 200) as a successful response from the indexing priority API endpoint

## Test plan
- [ ] Verify that references with invalid embeddings are marked as job failures without calling the priority API
- [ ] Verify that references with valid embeddings call `set_indexing_priority` and mark jobs based on the API response
- [ ] Confirm that HTTP 201 responses from the priority endpoint are treated as successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)