### PR TITLE
feat(SCRUM-5873): switch non-BERT pipelines from TEI to Markdown

### DIFF
--- a/agr_dataset_manager/dataset_downloader.py
+++ b/agr_dataset_manager/dataset_downloader.py
@@ -3,84 +3,46 @@ import csv
 import logging
 import os
 
-from lxml import etree
-
-from utils.abc_utils import (get_curie_from_xref, download_main_pdf, convert_pdf_with_grobid,
-                             download_tei_files_for_references, download_bib_data_for_references)
+from utils.abc_utils import (get_curie_from_xref,
+                             download_md_files_for_references, download_bib_data_for_references)
 
 logger = logging.getLogger(__name__)
 
 blue_api_base_url = os.environ.get('API_SERVER', "literature-rest.alliancegenome.org")
 
 
-def check_conversion_failure(tei_content):
-    """ Check if the TEI file content indicates a failed conversion. Args: tei_content (str): The TEI file content as
-    a string. Returns: bool: True if the conversion failed, False otherwise.
+def download_md_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative, output_dir,
+                                              mod_abbreviation):
+    """Populate ``output_dir/{positive,negative}`` with one ``.md`` file per reference.
+
+    Source priority (handled inside :func:`download_md_files_for_references`):
+
+    1. Main MD file from ABC (``converted_merged_main`` / ``.md``).
+    2. TEI file from ABC, converted on the fly to Markdown via the shared library.
+    3. Server-side on-demand conversion via
+       ``GET /reference/referencefile/conversion_request/{curie}`` (PDF or
+       nXML in ABC → MD), enabled by ``request_conversion=True``. This
+       replaces the older local Grobid PDF→TEI→MD path.
     """
-    try:  # Parse the TEI content
-        root = etree.fromstring(tei_content)  # Check for empty elements that indicate failure
-        title = root.xpath('//tei:title[@level="a"]', namespaces={'tei': 'http://www.tei-c.org/ns/1.0'})
-        # Define conditions for failure
-        if not title or not title[0].text:
-            return True
-    except etree.XMLSyntaxError:  # If parsing fails, it indicates a failure
-        return True
-
-
-def download_tei_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative, output_dir,
-                                               mod_abbreviation):
-    logger.info(f"Positive tei files download started. Number of files to download: {len(reference_ids_positive)}")
+    logger.info(f"Positive MD files download started. Number of files to download: {len(reference_ids_positive)}")
     output_dir_positive = os.path.join(output_dir, "positive")
-    download_tei_files_for_references(reference_ids_positive, output_dir_positive, mod_abbreviation)
-    logger.info(f"Negative tei files download started. Number of files to download: {len(reference_ids_negative)}")
+    download_md_files_for_references(reference_ids_positive, output_dir_positive,
+                                     mod_abbreviation, request_conversion=True)
+    logger.info(f"Negative MD files download started. Number of files to download: {len(reference_ids_negative)}")
     output_dir_negative = os.path.join(output_dir, "negative")
-    download_tei_files_for_references(reference_ids_negative, output_dir_negative, mod_abbreviation)
+    download_md_files_for_references(reference_ids_negative, output_dir_negative,
+                                     mod_abbreviation, request_conversion=True)
 
-    # Count the TEI files in the positive and negative directories
-    downloaded_reference_ids_positive = [name[:-4].replace("_", ":") for name in os.listdir(
-        output_dir_positive) if name.endswith('.tei')]
-    downloaded_reference_ids_negative = [name[:-4].replace("_", ":") for name in os.listdir(
-        output_dir_negative) if name.endswith('.tei')]
-
-    logger.info(f"Downloaded {len(downloaded_reference_ids_positive)} positive TEI files.")
-    logger.info(f"Downloaded {len(downloaded_reference_ids_negative)} negative TEI files.")
-
-    # after batch download tei file, first check if tei file exist, if not, then download pdf and convert to tei file
-    logger.info("Starting PDF download and TEI conversion for files that were not available in TEI format in the ABC.")
-    remaining_reference_ids_positive = set(reference_ids_positive) - set(downloaded_reference_ids_positive)
-    remaining_reference_ids_negative = set(reference_ids_negative) - set(downloaded_reference_ids_negative)
-    agrkb_positive_negative = {reference_curie: "positive" for reference_curie in remaining_reference_ids_positive}
-    agrkb_positive_negative.update({reference_curie: "negative" for reference_curie in
-                                    remaining_reference_ids_negative})
-    for (agrkb_id, category) in agrkb_positive_negative.items():
-        file_name = agrkb_id.replace(":", "_")
-        category_dir = os.path.join(output_dir, category)
-        tei_path = os.path.join(category_dir, f"{file_name}.tei")
-
-        # Check if TEI file already exists
-        if os.path.exists(tei_path):
-            continue
-        else:
-            logger.info(f"Downloading PDF for reference {agrkb_id} as {category}")
-            pdf_file_path = os.path.join(category_dir, f"{file_name}.pdf")
-            download_main_pdf(agrkb_id, mod_abbreviation, file_name, category_dir)
-            if not os.path.exists(pdf_file_path):
-                logger.error(f"Cannot find {file_name}.pdf")
-                continue
-
-            # Convert PDF to TEI
-            pdf_content = open(pdf_file_path, "rb")
-            logger.info("Converting PDF to TEI")
-            response = convert_pdf_with_grobid(pdf_content.read())
-
-            if response.status_code == 200 and not check_conversion_failure(response.content):
-                tei_path = os.path.join(category_dir, f"{file_name}.tei")
-                with open(tei_path, 'wb') as tei_file:
-                    tei_file.write(response.content)
-                logger.info(f"Converted {file_name}.pdf to TEI format")
-            else:
-                logger.error(f"Failed to convert {file_name}.pdf to TEI. Status code: {response.status_code}")
-            os.remove(pdf_file_path)
+    downloaded_reference_ids_positive = [
+        os.path.splitext(name)[0].replace("_", ":") for name in os.listdir(output_dir_positive)
+        if name.endswith(".md")
+    ]
+    downloaded_reference_ids_negative = [
+        os.path.splitext(name)[0].replace("_", ":") for name in os.listdir(output_dir_negative)
+        if name.endswith(".md")
+    ]
+    logger.info(f"Downloaded {len(downloaded_reference_ids_positive)} positive MD files.")
+    logger.info(f"Downloaded {len(downloaded_reference_ids_negative)} negative MD files.")
 
 
 def download_prioritized_bib_data(reference_ids_priority_1, reference_ids_priority_2,
@@ -99,7 +61,7 @@ def download_prioritized_bib_data(reference_ids_priority_1, reference_ids_priori
     download_bib_data_for_references(reference_ids_priority_3, output_dir_priority_3, mod_abbreviation)
 
 
-def download_and_categorize_tei_files_from_csv(csv_file, output_dir, mod_abbreviation, start_agrkbid=None):
+def download_and_categorize_md_files_from_csv(csv_file, output_dir, mod_abbreviation, start_agrkbid=None):
     os.makedirs(os.path.join(output_dir, "positive"), exist_ok=True)
     os.makedirs(os.path.join(output_dir, "negative"), exist_ok=True)
 
@@ -129,20 +91,19 @@ def download_and_categorize_tei_files_from_csv(csv_file, output_dir, mod_abbrevi
             category = "positive" if label == "1" else "negative"
             file_name = agrkb_id.replace(":", "_")
             category_dir = os.path.join(output_dir, category)
-            tei_path = os.path.join(category_dir, f"{file_name}.tei")
+            md_path = os.path.join(category_dir, f"{file_name}.md")
 
-            # Check if TEI file already exists
-            if os.path.exists(tei_path):
-                logger.info(f"Skipping {agrkb_id} as TEI file already exists")
+            if os.path.exists(md_path):
+                logger.info(f"Skipping {agrkb_id} as MD file already exists")
                 continue
-            else:
-                if category == "positive":
-                    reference_ids_positive.append(agrkb_id)
-                else:
-                    reference_ids_negative.append(agrkb_id)
 
-    download_tei_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative, output_dir,
-                                               mod_abbreviation)
+            if category == "positive":
+                reference_ids_positive.append(agrkb_id)
+            else:
+                reference_ids_negative.append(agrkb_id)
+
+    download_md_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative, output_dir,
+                                              mod_abbreviation)
 
 
 def main():
@@ -163,7 +124,7 @@ def main():
     out_dir = os.path.abspath(args.output_dir)
     os.makedirs(out_dir, exist_ok=True)
 
-    download_and_categorize_tei_files_from_csv(args.csv_file, out_dir, args.mod_abbreviation, args.start_agrkbid)
+    download_and_categorize_md_files_from_csv(args.csv_file, out_dir, args.mod_abbreviation, args.start_agrkbid)
 
 
 if __name__ == '__main__':

--- a/agr_dataset_manager/download_reference_files_from_abc.py
+++ b/agr_dataset_manager/download_reference_files_from_abc.py
@@ -2,10 +2,12 @@ import argparse
 import os
 import logging
 from utils.abc_utils import (
+    download_md_files_for_references,
     download_tei_files_for_references,
     download_main_pdf,
-    get_pmids_from_reference_curies
+    get_pmids_from_reference_curies,
 )
+from utils.md_utils import convert_all_md_files_in_dir_to_txt
 from utils.tei_utils import convert_all_tei_files_in_dir_to_txt
 
 # Configure the logger
@@ -62,6 +64,21 @@ def download_tei_files(output_directory, mod_abbreviation, curie_list):
         logger.error(f"Error downloading TEI files: {e}")
 
 
+def download_md_files(output_directory, mod_abbreviation, curie_list):
+    """
+    Download Markdown files (with TEI->MD fallback) for references and save them
+    in the specified directory.
+    """
+    os.makedirs(output_directory, exist_ok=True)
+    logger.info(f"Downloading Markdown files to {output_directory} for MOD {mod_abbreviation}...")
+
+    try:
+        download_md_files_for_references(reference_curies=curie_list, mod_abbreviation=mod_abbreviation,
+                                         output_dir=output_directory)
+    except Exception as e:
+        logger.error(f"Error downloading Markdown files: {e}")
+
+
 def convert_tei_to_txt(tei_directory):
     """
     Convert TEI files in the specified directory to text files
@@ -74,6 +91,16 @@ def convert_tei_to_txt(tei_directory):
         logger.info("TEI files converted to text successfully.")
     except Exception as e:
         logger.error(f"Error converting TEI files: {e}")
+
+
+def convert_md_to_txt(md_directory):
+    """Convert Markdown files in ``md_directory`` to plain-text ``.txt`` files."""
+    logger.info(f"Converting Markdown files in {md_directory} to text files...")
+    try:
+        convert_all_md_files_in_dir_to_txt(md_directory)
+        logger.info("Markdown files converted to text successfully.")
+    except Exception as e:
+        logger.error(f"Error converting Markdown files: {e}")
 
 
 def rename_files_in_dir_from_agrkb_to_pmid(curie_to_pmid_dict: dict, dir_to_convert: str, file_extension: str = "pdf"):
@@ -98,9 +125,9 @@ def main():
     )
     parser.add_argument(
         "--download",
-        choices=["pdf", "tei", "text"],
+        choices=["pdf", "tei", "md", "text"],
         required=True,
-        help="Specify the type of file to download or save. Options: 'pdf', 'tei', or 'text' (converted from TEI)."
+        help="Specify the type of file to download or save. Options: 'pdf', 'tei', 'md' (with TEI->MD fallback), or 'text' (Markdown converted to plain text)."
     )
     parser.add_argument(
         "--input-file",
@@ -132,13 +159,16 @@ def main():
     elif args.download == "tei":
         download_tei_files(output_directory, args.mod_abbreviation, curie_list)
         rename_files_in_dir_from_agrkb_to_pmid(curie_to_pmid_dict, output_directory, file_extension="tei")
+    elif args.download == "md":
+        download_md_files(output_directory, args.mod_abbreviation, curie_list)
+        rename_files_in_dir_from_agrkb_to_pmid(curie_to_pmid_dict, output_directory, file_extension="md")
     elif args.download == "text":
-        # First, download TEI files, then convert them to text files
-        download_tei_files(output_directory, args.mod_abbreviation, curie_list)
-        rename_files_in_dir_from_agrkb_to_pmid(curie_to_pmid_dict, output_directory, file_extension="tei")
-        convert_tei_to_txt(output_directory)
+        # Download MD files (with TEI->MD fallback), then convert them to plain text.
+        download_md_files(output_directory, args.mod_abbreviation, curie_list)
+        rename_files_in_dir_from_agrkb_to_pmid(curie_to_pmid_dict, output_directory, file_extension="md")
+        convert_md_to_txt(output_directory)
     else:
-        logger.error("Invalid option for --download. Use 'pdf', 'tei', or 'text'.")
+        logger.error("Invalid option for --download. Use 'pdf', 'tei', 'md', or 'text'.")
 
 
 if __name__ == "__main__":

--- a/agr_dataset_manager/generate_embedding_matrix.py
+++ b/agr_dataset_manager/generate_embedding_matrix.py
@@ -9,13 +9,13 @@ import pandas as pd
 from gensim.models import KeyedVectors
 
 from utils.embedding import get_document_embedding, load_embedding_model
-from utils.tei_utils import AllianceTEI
+from utils.md_utils import AllianceMarkdown
 
 
 logger = logging.getLogger(__name__)
 
 
-def process_tei_files(base_folder, all_mods, embedding_model, output_file):
+def process_md_files(base_folder, all_mods, embedding_model, output_file):
     embeddings = defaultdict(lambda: defaultdict(list))
     processed_curies = 0
 
@@ -31,7 +31,9 @@ def process_tei_files(base_folder, all_mods, embedding_model, output_file):
             logger.warning(f"Warning: MOD folder {mod} does not exist.")
             continue
         for filename in os.listdir(mod_folder):
-            curie = filename.replace(".tei", "").replace("_", ":")
+            if not filename.endswith(".md"):
+                continue
+            curie = os.path.splitext(filename)[0].replace("_", ":")
             file_path = os.path.join(mod_folder, filename)
             all_files[curie].append((file_path, mod))
     curies_to_process = list(all_files.keys())
@@ -40,14 +42,13 @@ def process_tei_files(base_folder, all_mods, embedding_model, output_file):
     for curie in curies_to_process:
         for file_path, mod in all_files[curie]:
             filename = os.path.basename(file_path)
-            curie = filename.replace(".tei", "").replace("_", ":")
+            curie = os.path.splitext(filename)[0].replace("_", ":")
 
             logger.debug(f"Processing file {filename} for {mod}...")
-            # Extract fulltext using AllianceTEI
-            tei_parser = AllianceTEI()
+            md_parser = AllianceMarkdown()
             try:
-                tei_parser.load_from_file(file_path)
-                fulltext = tei_parser.get_fulltext()
+                md_parser.load_from_file(file_path)
+                fulltext = md_parser.get_fulltext()
             except Exception as e:
                 logger.error(f"Error processing file {filename}: {e}")
                 continue
@@ -103,12 +104,12 @@ def save_to_csv(aggregated_embedding_data, output_file):
 # Main function
 def main():
     # Parse arguments
-    parser = argparse.ArgumentParser(description="Generate a matrix of average word embeddings for TEI files.")
+    parser = argparse.ArgumentParser(description="Generate a matrix of average word embeddings for Markdown files.")
     parser.add_argument(
         "--input_folder",
         type=str,
         required=True,
-        help="Path to the base folder containing MOD subfolders with TEI files."
+        help="Path to the base folder containing MOD subfolders with Markdown files."
     )
     parser.add_argument(
         "--output_file",
@@ -144,9 +145,9 @@ def main():
 
     embedding_model = load_embedding_model(args.embedding_model_path)
 
-    # Process TEI files and generate embeddings
-    print(f"Processing TEI files in folder: {input_folder}")
-    process_tei_files(input_folder, mods, embedding_model, output_file)
+    # Process Markdown files and generate embeddings
+    print(f"Processing Markdown files in folder: {input_folder}")
+    process_md_files(input_folder, mods, embedding_model, output_file)
 
 
 # Entry point

--- a/agr_document_classifier/agr_antibody_string_matching_classifier.py
+++ b/agr_document_classifier/agr_antibody_string_matching_classifier.py
@@ -1,8 +1,8 @@
 """WB antibody string-matching topic classifier (SCRUM-5601).
 
-Pulls jobs from ABC, downloads TEIs, applies the rule engine in
-`antibody_rules.py`, and POSTs TopicEntityTags with positive/negative +
-matched-span notes back to ABC.
+Pulls jobs from ABC, downloads main MD (with TEI fallback), applies the
+rule engine in `antibody_rules.py`, and POSTs TopicEntityTags with
+positive/negative + matched-span notes back to ABC.
 
 Mirrors the structure of agr_document_classifier_classify.py without the
 ML-model download/predict path.
@@ -19,7 +19,7 @@ from argparse import Namespace
 
 from agr_document_classifier.antibody_rules import build_regexes, match_antibody_spans
 from utils.abc_utils import (
-    download_tei_files_for_references,
+    download_md_files_for_references,
     get_cached_mod_id_from_abbreviation,
     get_tet_source_id,
     load_all_jobs,
@@ -30,7 +30,7 @@ from utils.abc_utils import (
     set_job_success,
 )
 from utils.ateam_utils import get_all_curated_entities
-from utils.tei_utils import AllianceTEI
+from utils.md_utils import AllianceMarkdown
 
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 
@@ -94,7 +94,7 @@ def _prepare_dir() -> None:
 
 
 def _curie_from_filename(file_path: str) -> str:
-    """`AGRKB_101000000000001.tei` -> `AGRKB:101000000000001`."""
+    """`AGRKB_101000000000001.md` -> `AGRKB:101000000000001`."""
     base = os.path.basename(file_path)
     name = base.split(".")[0]
     return name.replace("_", ":")
@@ -138,22 +138,22 @@ def _process_batch(batch: list, rules, tet_source_id: int, topic: str,
                    *, test_mode: bool) -> None:
     curie_to_job = {job["reference_curie"]: job for job in batch}
     _prepare_dir()
-    download_tei_files_for_references(list(curie_to_job.keys()), TO_CLASSIFY_DIR, "WB")
+    download_md_files_for_references(list(curie_to_job.keys()), TO_CLASSIFY_DIR, "WB")
 
     for fname in os.listdir(TO_CLASSIFY_DIR):
         path = os.path.join(TO_CLASSIFY_DIR, fname)
         curie = _curie_from_filename(path)
         job = curie_to_job.get(curie)
         if job is None:
-            logger.warning(f"TEI {fname} has no matching job; skipping")
+            logger.warning(f"MD {fname} has no matching job; skipping")
             continue
 
         try:
-            tei = AllianceTEI()
-            tei.load_from_file(path)
-            sentences = tei.get_sentences()
+            md = AllianceMarkdown()
+            md.load_from_file(path)
+            sentences = md.get_sentences()
         except Exception as exc:
-            logger.error(f"TEI parse failed for {curie}: {exc}")
+            logger.error(f"MD parse failed for {curie}: {exc}")
             if not test_mode:
                 set_job_started(job)
                 set_job_failure(job)

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -13,7 +13,7 @@ import numpy as np
 import requests.exceptions
 from gensim.models import KeyedVectors
 
-from utils.abc_utils import download_tei_files_for_references, send_classification_tag_to_abc, \
+from utils.abc_utils import download_md_files_for_references, send_classification_tag_to_abc, \
     get_cached_mod_abbreviation_from_id, \
     set_job_success, get_tet_source_id, set_job_started, \
     download_abc_model, set_job_failure, load_all_jobs, get_model_data, \
@@ -142,8 +142,8 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
                       test_mode):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     prepare_classification_directory()
-    download_tei_files_for_references(list(reference_curie_job_map.keys()),
-                                      "/data/agr_document_classifier/to_classify", mod_abbr)
+    download_md_files_for_references(list(reference_curie_job_map.keys()),
+                                     "/data/agr_document_classifier/to_classify", mod_abbr)
     files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
         embedding_model=embedding_model,
         classifier_model=classifier_model,
@@ -151,7 +151,7 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
     if test_mode:
         for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                           valid_embeddings):
-            reference_curie = file_path.split("/")[-1].replace("_", ":")[:-4]
+            reference_curie = os.path.splitext(file_path.split("/")[-1])[0].replace("_", ":")
             if not valid_embedding:
                 logger.warning(f"Invalid embedding for file: {file_path}. Skipping.")
                 continue
@@ -186,7 +186,7 @@ def send_classification_results(files_loaded, classifications, conf_scores, vali
 
     for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                       valid_embeddings):
-        reference_curie = file_path.split("/")[-1].replace("_", ":")[:-4]
+        reference_curie = os.path.splitext(file_path.split("/")[-1])[0].replace("_", ":")
         if not valid_embedding:
             logger.warning(f"Invalid embedding for file: {file_path}. Setting job to failed.")
             set_job_started(reference_curie_job_map[reference_curie])

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -19,7 +19,7 @@ from sklearn.ensemble import IsolationForest
 from sklearn.covariance import EllipticEnvelope
 from sklearn.neighbors import LocalOutlierFactor
 
-from agr_dataset_manager.dataset_downloader import download_tei_files_from_abc_or_convert_pdf
+from agr_dataset_manager.dataset_downloader import download_md_files_from_abc_or_convert_pdf
 from models import POSSIBLE_CLASSIFIERS
 from utils.abc_utils import get_training_set_from_abc, upload_ml_model, get_reference_date
 from utils.embedding import load_embedding_model, get_document_embedding
@@ -479,9 +479,9 @@ def download_training_set(args, training_data_dir):
     shutil.rmtree(os.path.join(training_data_dir, "negative"), ignore_errors=True)
     os.makedirs(os.path.join(training_data_dir, "positive"), exist_ok=True)
     os.makedirs(os.path.join(training_data_dir, "negative"), exist_ok=True)
-    download_tei_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative,
-                                               output_dir=training_data_dir,
-                                               mod_abbreviation=args.mod_train)
+    download_md_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative,
+                                              output_dir=training_data_dir,
+                                              mod_abbreviation=args.mod_train)
     return training_set
 
 

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -22,10 +22,6 @@ import nltk
 import numpy as np
 import requests.exceptions
 from gensim.models import KeyedVectors
-from grobid_client import Client
-from grobid_client.api.pdf import process_fulltext_document
-from grobid_client.models import Article, ProcessForm
-from grobid_client.types import TEI, File
 from nltk.corpus import stopwords
 from nltk.tokenize import word_tokenize
 from sklearn.model_selection import train_test_split, RandomizedSearchCV, StratifiedKFold
@@ -37,13 +33,13 @@ from sklearn.ensemble import RandomForestClassifier
 from imblearn.under_sampling import RandomUnderSampler
 
 from agr_dataset_manager.dataset_downloader import download_prioritized_bib_data
-from utils.abc_utils import download_tei_files_for_references, send_classification_tag_to_abc, \
+from utils.abc_utils import download_md_files_for_references, send_classification_tag_to_abc, \
     get_cached_mod_abbreviation_from_id, download_bib_data_for_references, \
     download_bib_data_for_need_prioritization_references, set_job_success, get_tet_source_id, \
     set_job_started, get_training_set_from_abc, upload_ml_model, download_abc_model, \
     set_job_failure, load_all_jobs, set_indexing_priority, get_model_data
 from utils.embedding import load_embedding_model, get_document_embedding
-from utils.tei_utils import get_sentences_from_tei_section
+from utils.md_utils import AllianceMarkdown
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 
 nltk.download('stopwords')
@@ -273,43 +269,20 @@ def remove_stopwords(text):
 
 def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
     documents = []
-    client = None
     for file_path in glob.glob(os.path.join(input_docs_dir, "*")):
         num_errors = 0
-        file_obj = Path(file_path)
-        # Process TEI or PDF files as before
-        if file_path.endswith(".tei") or file_path.endswith(".pdf"):
-            with file_obj.open("rb") as fin:
-                if file_path.endswith(".pdf"):
-                    if client is None:
-                        client = Client(base_url=os.environ.get("GROBID_API_URL"), timeout=1000, verify_ssl=False)
-                    logger.info("Started pdf to TEI conversion")
-                    form = ProcessForm(
-                        segment_sentences="1",
-                        input_=File(file_name=file_obj.name, payload=fin, mime_type="application/pdf")
-                    )
-                    r = process_fulltext_document.sync_detailed(client=client, multipart_data=form)
-                    file_stream = r.content
-                else:
-                    file_stream = fin
-                try:
-                    article: Article = TEI.parse(file_stream, figures=True)
-                except Exception:
-                    num_errors += 1
-                    continue
-                sentences = []
-                for section in article.sections:
-                    sec_sentences, sec_num_errors = get_sentences_from_tei_section(section)
-                    sentences.extend(sec_sentences)
-                    num_errors += sec_num_errors
-                abstract = ""
-                for section in article.sections:
-                    if section.name == "ABSTRACT":
-                        abs_sentences, num_errors = get_sentences_from_tei_section(section)
-                        abstract = " ".join(abs_sentences)
-                        break
-                documents.append((file_path, " ".join(sentences), article.title, abstract))
-        # process plain text files with metadata in key|value format
+        if file_path.endswith(".md"):
+            if ".supp_" in os.path.basename(file_path):
+                # Supplement files are folded in via AllianceMarkdown when callers
+                # opt in to include_supplements; never load them as standalone docs.
+                continue
+            try:
+                md = AllianceMarkdown()
+                md.load_from_file(file_path)
+                documents.append((file_path, md.get_fulltext(), md.get_title(), md.get_abstract()))
+            except Exception as e:
+                num_errors += 1
+                logger.error(f"Error parsing MD file {file_path}: {e}")
         elif file_path.endswith(".txt"):
             try:
                 with file_obj.open("r", encoding="utf-8") as fin:
@@ -664,8 +637,8 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model):
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, ml_model_id):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     prepare_classification_directory()
-    download_tei_files_for_references(list(reference_curie_job_map.keys()),
-                                      f"{root_data_path}to_classify", mod_abbr)
+    download_md_files_for_references(list(reference_curie_job_map.keys()),
+                                     f"{root_data_path}to_classify", mod_abbr)
     files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
         embedding_model=embedding_model,
         classifier_model=classifier_model,
@@ -686,7 +659,7 @@ def send_classification_results(files_loaded, classifications, conf_scores, vali
     logger.info("Sending classification tags to ABC.")
     for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                       valid_embeddings):
-        reference_curie = file_path.split("/")[-1].replace("_", ":")[:-4]
+        reference_curie = os.path.splitext(file_path.split("/")[-1])[0].replace("_", ":")
         if not valid_embedding:
             logger.warning(f"Invalid embedding for file: {file_path}. Setting job to failed.")
             set_job_started(reference_curie_job_map[reference_curie])

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -285,7 +285,7 @@ def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
                 logger.error(f"Error parsing MD file {file_path}: {e}")
         elif file_path.endswith(".txt"):
             try:
-                with file_obj.open("r", encoding="utf-8") as fin:
+                with open(file_path, "r", encoding="utf-8") as fin:
                     content = fin.read()
                 data = {}
                 for line in content.splitlines():

--- a/agr_entity_extractor/agr_entity_extraction_pipeline.py
+++ b/agr_entity_extractor/agr_entity_extraction_pipeline.py
@@ -10,9 +10,9 @@ import requests
 from transformers import pipeline
 
 from utils.abc_utils import load_all_jobs, get_cached_mod_abbreviation_from_id, get_tet_source_id, download_abc_model, \
-    download_tei_files_for_references, set_job_started, set_job_success, send_entity_tag_to_abc, get_model_data, \
+    download_md_files_for_references, set_job_started, set_job_success, send_entity_tag_to_abc, get_model_data, \
     set_job_failure, set_blue_api_base_url
-from utils.tei_utils import AllianceTEI
+from utils.md_utils import AllianceMarkdown
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +76,8 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
         os.makedirs("/data/agr_entity_extraction/to_extract", exist_ok=True)
         for file in os.listdir("/data/agr_entity_extraction/to_extract"):
             os.remove(os.path.join("/data/agr_entity_extraction/to_extract", file))
-        download_tei_files_for_references(list(reference_curie_job_map.keys()),
-                                          "/data/agr_entity_extraction/to_extract", mod_abbr)
+        download_md_files_for_references(list(reference_curie_job_map.keys()),
+                                         "/data/agr_entity_extraction/to_extract", mod_abbr)
 
         for threshold in thresholds:
             entity_extraction_model.tfidf_threshold = threshold
@@ -86,16 +86,16 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
             for file in os.listdir("/data/agr_entity_extraction/to_extract"):
                 curie = file.split(".")[0].replace("_", ":")
                 try:
-                    tei_obj = AllianceTEI()
-                    tei_obj.load_from_file(f"/data/agr_entity_extraction/to_extract/{file}")
+                    md_obj = AllianceMarkdown()
+                    md_obj.load_from_file(f"/data/agr_entity_extraction/to_extract/{file}")
                 except Exception as e:
-                    logger.warning(f"Error loading TEI file for {curie}: {str(e)}. Skipping.")
+                    logger.warning(f"Error loading MD file for {curie}: {str(e)}. Skipping.")
                     continue
 
                 nlp_pipeline = pipeline("ner", model=entity_extraction_model,
                                         tokenizer=entity_extraction_model.tokenizer)
                 try:
-                    fulltext = tei_obj.get_fulltext()
+                    fulltext = md_obj.get_fulltext(include_keywords=True)
                 except Exception as e:
                     logger.error(f"Error getting fulltext for {curie}: {str(e)}. Skipping.")
                     continue
@@ -104,10 +104,10 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
                 entities_in_fulltext = [result['word'] for result in results if result['entity'] == "ENTITY"]
                 entities_to_extract = set(entity_extraction_model.entities_to_extract)
                 entities_in_title = set(
-                    entity_extraction_model.tokenizer.tokenize(tei_obj.get_title() or "")).intersection(
+                    entity_extraction_model.tokenizer.tokenize(md_obj.get_title() or "")).intersection(
                     entities_to_extract)
                 entities_in_abstract = set(
-                    entity_extraction_model.tokenizer.tokenize(tei_obj.get_abstract() or "")).intersection(
+                    entity_extraction_model.tokenizer.tokenize(md_obj.get_abstract() or "")).intersection(
                     entities_to_extract)
                 all_entities = set(entities_in_fulltext).union(entities_in_title).union(entities_in_abstract)
 
@@ -166,16 +166,16 @@ def process_entity_extraction_jobs(mod_id, topic, jobs):  # noqa C901
         logger.info("Cleaning up existing files in the to_extract directory")
         for file in os.listdir("/data/agr_entity_extraction/to_extract"):
             os.remove(os.path.join("/data/agr_entity_extraction/to_extract", file))
-        download_tei_files_for_references(list(reference_curie_job_map.keys()),
-                                          "/data/agr_entity_extraction/to_extract", mod_abbr)
+        download_md_files_for_references(list(reference_curie_job_map.keys()),
+                                         "/data/agr_entity_extraction/to_extract", mod_abbr)
         for file in os.listdir("/data/agr_entity_extraction/to_extract"):
             curie = file.split(".")[0].replace("_", ":")
             job = reference_curie_job_map[curie]
             try:
-                tei_obj = AllianceTEI()
-                tei_obj.load_from_file(f"/data/agr_entity_extraction/to_extract/{file}")
+                md_obj = AllianceMarkdown()
+                md_obj.load_from_file(f"/data/agr_entity_extraction/to_extract/{file}")
             except Exception as e:
-                logger.warning(f"Error loading TEI file for {curie}: {str(e)}. Skipping.")
+                logger.warning(f"Error loading MD file for {curie}: {str(e)}. Skipping.")
                 continue
             entity_extraction_model.load_entities_dynamically()
             nlp_pipeline = pipeline("ner", model=entity_extraction_model,
@@ -183,17 +183,17 @@ def process_entity_extraction_jobs(mod_id, topic, jobs):  # noqa C901
             title = ""
             abstract = ""
             try:
-                fulltext = tei_obj.get_fulltext()
+                fulltext = md_obj.get_fulltext()
             except Exception as e:
                 logger.error(f"Error getting fulltext for {curie}: {str(e)}. Skipping.")
                 set_job_started(job)
                 set_job_failure(job)
             try:
-                abstract = tei_obj.get_abstract()
+                abstract = md_obj.get_abstract()
             except Exception as e:
                 logger.warning(f"Error getting abstract for {curie}: {str(e)}. Ignoring field.")
             try:
-                title = tei_obj.get_title()
+                title = md_obj.get_title()
             except Exception as e:
                 logger.warning(f"Error getting title for {curie}: {str(e)}. Ignoring field.")
             all_entities = extract_all_entities(nlp_pipeline=nlp_pipeline, fulltext=fulltext, title=title,

--- a/agr_entity_extractor/agr_entity_extraction_pipeline_fast.py
+++ b/agr_entity_extractor/agr_entity_extraction_pipeline_fast.py
@@ -34,7 +34,7 @@ from utils.abc_utils import (
     get_cached_mod_abbreviation_from_id,
     get_tet_source_id,
     download_abc_model,
-    download_tei_files_for_references,
+    download_md_files_for_references,
     set_job_started,
     set_job_success,
     send_entity_tag_to_abc,
@@ -42,7 +42,7 @@ from utils.abc_utils import (
     set_job_failure,
 )
 from utils.ateam_utils import get_all_curated_entities
-from utils.tei_utils import AllianceTEI
+from utils.md_utils import AllianceMarkdown
 
 from utils.entity_extraction_utils import (
     prime_model_entities as prime_model_entities_shared,
@@ -259,7 +259,7 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
         os.makedirs(out_dir, exist_ok=True)
         for f in os.listdir(out_dir):
             os.remove(os.path.join(out_dir, f))
-        download_tei_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
+        download_md_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
 
         for th in thresholds:
             entity_model.tfidf_threshold = th
@@ -269,18 +269,15 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
             for f in os.listdir(out_dir):
                 curie = f.split(".")[0].replace("_", ":")
                 try:
-                    tei = AllianceTEI()
-                    tei.load_from_file(os.path.join(out_dir, f))
+                    md = AllianceMarkdown()
+                    md.load_from_file(os.path.join(out_dir, f))
                 except Exception as e:
-                    logger.warning("Error loading TEI for %s: %s. Skipping.", curie, e)
+                    logger.warning("Error loading MD for %s: %s. Skipping.", curie, e)
                     continue
 
                 nlp = pipeline("ner", model=entity_model, tokenizer=entity_model.tokenizer)
                 try:
-                    if entity_model.topic == "ATP:0000006":   # allele
-                        fulltext = tei.get_fulltext(include_attributes=True)
-                    else:
-                        fulltext = tei.get_fulltext()
+                    fulltext = md.get_fulltext()
                 except Exception as e:
                     logger.error("Error getting fulltext for %s: %s. Skipping.", curie, e)
                     continue
@@ -288,8 +285,8 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
                 results = nlp(fulltext)
                 ents_ft = [r['word'] for r in results if r.get('entity') == "ENTITY"]
                 ents_to_extract = set(entity_model.entities_to_extract)
-                ents_title = set(entity_model.tokenizer.tokenize(tei.get_title() or "")) & ents_to_extract
-                ents_abs = set(entity_model.tokenizer.tokenize(tei.get_abstract() or "")) & ents_to_extract
+                ents_title = set(entity_model.tokenizer.tokenize(md.get_title() or "")) & ents_to_extract
+                ents_abs = set(entity_model.tokenizer.tokenize(md.get_abstract() or "")) & ents_to_extract
                 all_ents = set(ents_ft) | ents_title | ents_abs
 
                 all_low = {e.lower() for e in all_ents}
@@ -313,7 +310,7 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
 # --------------------------------------------------------------------- #
 # Core processing                                                       #
 # --------------------------------------------------------------------- #
-def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False, test_fh=None, ner_batch_size: int = 16, prefilter: bool = True, log_every: int = 10, combined_tei_dir: bool = False):  # noqa: C901
+def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False, test_fh=None, ner_batch_size: int = 16, prefilter: bool = True, log_every: int = 10, combined_md_dir: bool = False):  # noqa: C901
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
 
     tet_source_id = None
@@ -352,23 +349,20 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
 
     ner_pipe = get_pipe(mod_abbr, topic, model)
 
-    # ---------------- combined TEI dir path ---------------- #
-    if combined_tei_dir:
-        logger.info("Processing all combined TEI files in %s (files will not be deleted)", combined_tei_dir)
-        for fname in sorted(os.listdir(combined_tei_dir)):
-            if not fname.endswith(".tei"):
+    # ---------------- combined MD dir path ---------------- #
+    if combined_md_dir:
+        logger.info("Processing all combined MD files in %s (files will not be deleted)", combined_md_dir)
+        for fname in sorted(os.listdir(combined_md_dir)):
+            if not fname.endswith(".md"):
                 continue
-            curie = fname.replace(".tei", "")
-            path = os.path.join(combined_tei_dir, fname)
+            curie = fname.replace(".md", "")
+            path = os.path.join(combined_md_dir, fname)
             try:
-                tei = AllianceTEI()
-                tei.load_from_file(path)
-                title = tei.get_title() or ""
-                abstract = tei.get_abstract() or ""
-                if model.topic == "ATP:0000006":   # allele
-                    fulltext = tei.get_fulltext(include_attributes=True)
-                else:
-                    fulltext = tei.get_fulltext() or ""
+                md = AllianceMarkdown()
+                md.load_from_file(path)
+                title = md.get_title() or ""
+                abstract = md.get_abstract() or ""
+                fulltext = md.get_fulltext() or ""
             except Exception as e:
                 logger.warning("Failed to load/process %s: %s", fname, e)
                 continue
@@ -400,13 +394,13 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                                 ent_curie = resolve_entity_curie(model, ent, strict=True)
                             except KeyError:
                                 logger.info(
-                                    "ALLELE-REJECT: mapping KeyError for candidate '%s' in ref %s (combined TEI)",
+                                    "ALLELE-REJECT: mapping KeyError for candidate '%s' in ref %s (combined MD)",
                                     ent, curie,
                                 )
                                 continue
                             if not ent_curie:
                                 logger.info(
-                                    "ALLELE-REJECT: no CURIE found for candidate '%s' in ref %s (combined TEI)",
+                                    "ALLELE-REJECT: no CURIE found for candidate '%s' in ref %s (combined MD)",
                                     ent, curie,
                                 )
                                 continue
@@ -436,7 +430,7 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                         )
 
             logger.info("%s => %s", curie, all_entities)
-        logger.info("Finished processing combined TEI directory.")
+        logger.info("Finished processing combined MD directory.")
         return
 
     # ---------------- job-based processing ---------------- #
@@ -455,29 +449,26 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
         for f in os.listdir(out_dir):
             os.remove(os.path.join(out_dir, f))
 
-        download_tei_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
+        download_md_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
 
         metas: List[tuple[str, dict, str, str, str]] = []  # (curie, job, title, abstract, fulltext)
         texts_for_ner: List[str] = []
 
-        # ---- Prepare TEIs ----
+        # ---- Prepare MDs ----
         for fname in os.listdir(out_dir):
             curie = fname.split(".")[0].replace("_", ":")
             job = ref_map.get(curie)
             if job is None:
                 continue
             try:
-                tei = AllianceTEI()
-                tei.load_from_file(os.path.join(out_dir, fname))
+                md = AllianceMarkdown()
+                md.load_from_file(os.path.join(out_dir, fname))
             except Exception as e:
-                logger.warning("TEI load failed for %s: %s. Skipping.", curie, e)
+                logger.warning("MD load failed for %s: %s. Skipping.", curie, e)
                 continue
 
             try:
-                if model.topic == "ATP:0000006":   # allele
-                    fulltext = tei.get_fulltext(include_attributes=True)
-                else:
-                    fulltext = tei.get_fulltext() or ""
+                fulltext = md.get_fulltext() or ""
             except Exception as e:
                 logger.error("Fulltext error for %s: %s. Marking failure.", curie, e)
                 set_job_started(job)
@@ -485,12 +476,12 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                 continue
 
             try:
-                abstract = tei.get_abstract() or ""
+                abstract = md.get_abstract() or ""
             except Exception as e:
                 logger.warning("Abstract error for %s: %s. Ignoring.", curie, e)
                 abstract = ""
             try:
-                title = tei.get_title() or ""
+                title = md.get_title() or ""
             except Exception as e:
                 logger.warning("Title error for %s: %s. Ignoring.", curie, e)
                 title = ""
@@ -500,7 +491,7 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
             metas.append((curie, job, title, abstract, fulltext))
 
         if not texts_for_ner:
-            logger.info("No valid TEIs in this batch.")
+            logger.info("No valid MDs in this batch.")
             continue
 
         # ---- Run NER ----
@@ -587,8 +578,8 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
 def main():
     parser = argparse.ArgumentParser(description='Extract biological entities from documents')
     parser.add_argument(
-        "--combined-tei-dir", metavar="DIR",
-        help="Process every .combined.tei under this directory instead of downloading TEIs."
+        "--combined-md-dir", metavar="DIR",
+        help="Process every .md file under this directory instead of downloading MDs."
     )
     parser.add_argument("--tune-threshold", action="store_true",
                         help="Run find_best_tfidf_threshold on all jobs (slow, for experimentation only)")
@@ -682,7 +673,7 @@ def main():
                 ner_batch_size=args.ner_batch,
                 prefilter=not args.no_prefilter,
                 log_every=args.log_every,
-                combined_tei_dir=args.combined_tei_dir,
+                combined_md_dir=args.combined_md_dir,
             )
     finally:
         if test_fh:

--- a/agr_entity_extractor/agr_entity_extraction_pipeline_fast.py
+++ b/agr_entity_extractor/agr_entity_extraction_pipeline_fast.py
@@ -277,7 +277,11 @@ def find_best_tfidf_threshold(mod_id, topic, jobs, target_entities):
 
                 nlp = pipeline("ner", model=entity_model, tokenizer=entity_model.tokenizer)
                 try:
-                    fulltext = md.get_fulltext()
+                    fulltext = (
+                        md.get_fulltext(include_attributes=True)
+                        if entity_model.topic == "ATP:0000006"
+                        else md.get_fulltext()
+                    )
                 except Exception as e:
                     logger.error("Error getting fulltext for %s: %s. Skipping.", curie, e)
                     continue
@@ -362,7 +366,11 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                 md.load_from_file(path)
                 title = md.get_title() or ""
                 abstract = md.get_abstract() or ""
-                fulltext = md.get_fulltext() or ""
+                fulltext = (
+                    md.get_fulltext(include_attributes=True)
+                    if model.topic == "ATP:0000006"
+                    else md.get_fulltext()
+                ) or ""
             except Exception as e:
                 logger.warning("Failed to load/process %s: %s", fname, e)
                 continue
@@ -468,7 +476,11 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                 continue
 
             try:
-                fulltext = md.get_fulltext() or ""
+                fulltext = (
+                    md.get_fulltext(include_attributes=True)
+                    if model.topic == "ATP:0000006"
+                    else md.get_fulltext()
+                ) or ""
             except Exception as e:
                 logger.error("Fulltext error for %s: %s. Marking failure.", curie, e)
                 set_job_started(job)

--- a/agr_entity_extractor/agr_species_extraction_pipeline.py
+++ b/agr_entity_extractor/agr_species_extraction_pipeline.py
@@ -14,7 +14,7 @@ from utils.abc_utils import (
     get_cached_mod_abbreviation_from_id,
     get_tet_source_id,
     download_abc_model,
-    download_tei_files_for_references,
+    download_md_files_for_references,
     set_job_started,
     set_job_success,
     send_entity_tag_to_abc,
@@ -22,7 +22,7 @@ from utils.abc_utils import (
     set_job_failure
 )
 from utils.ateam_utils import get_all_curated_entities
-from utils.tei_utils import AllianceTEI
+from utils.md_utils import AllianceMarkdown
 from utils.species_text_norm import (
     normalize_species_aliases,
     expand_species_abbreviations,
@@ -109,7 +109,7 @@ def build_entities_from_results(results, title: str, abstract: str, fulltext: st
 # applying an NER (Named Entity Recognition) model to extract entities      #
 # for a specific mod_id and topic.                                          #
 # ------------------------------------------------------------------------- #
-def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False, test_fh=None, ner_batch_size: int = 16, prefilter: bool = True, log_every: int = 10, combined_tei_dir: bool = False, refresh_taxa_cache: bool = False):  # noqa: C901
+def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False, test_fh=None, ner_batch_size: int = 16, prefilter: bool = True, log_every: int = 10, combined_md_dir: bool = False, refresh_taxa_cache: bool = False):  # noqa: C901
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
 
     tet_source_id = None
@@ -171,23 +171,23 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
         logger.warning("Parent/child map is empty — ancestor pruning disabled for this run. Aborting.")
         return
 
-    # ---------------- NEW combined TEI DIR handling -------------------- #
-    if combined_tei_dir:
+    # ---------------- combined MD DIR handling ------------------------- #
+    if combined_md_dir:
         logger.info(
-            "Processing all combined TEI files in %s (files will not be deleted)",
-            combined_tei_dir
+            "Processing all combined MD files in %s (files will not be deleted)",
+            combined_md_dir
         )
-        for fname in sorted(os.listdir(combined_tei_dir)):
-            if not fname.endswith(".combined.tei"):
+        for fname in sorted(os.listdir(combined_md_dir)):
+            if not fname.endswith(".md"):
                 continue
-            curie = fname[:-len(".combined.tei")].replace("_", ":")
-            path = os.path.join(combined_tei_dir, fname)
+            curie = fname[:-len(".md")].replace("_", ":")
+            path = os.path.join(combined_md_dir, fname)
             try:
-                tei = AllianceTEI()
-                tei.load_from_file(path)
-                title = tei.get_title() or ""
-                abstract = tei.get_abstract() or ""
-                fulltext = tei.get_fulltext() or ""
+                md = AllianceMarkdown()
+                md.load_from_file(path)
+                title = md.get_title() or ""
+                abstract = md.get_abstract() or ""
+                fulltext = md.get_fulltext() or ""
             except Exception as e:
                 logger.warning("Failed to load/process %s: %s", fname, e)
                 continue
@@ -243,7 +243,7 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                     logger.info("%s: dropping ancestor '%s' (has a more specific descendant)", curie, d)
             logger.info("%s (raw)  = %s", curie, all_entities)
             logger.info("%s (dedup)= %s", curie, deduped_names)
-        logger.info("Finished processing combined TEI directory.")
+        logger.info("Finished processing combined MD directory.")
         return
 
     # --------------------------------------------------------------------- #
@@ -265,12 +265,12 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
         for f in os.listdir(out_dir):
             os.remove(os.path.join(out_dir, f))
 
-        download_tei_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
+        download_md_files_for_references(list(ref_map.keys()), out_dir, mod_abbr)
 
         metas: List[Tuple[str, dict, str, str, str]] = []  # (curie, job, title, abstract, fulltext)
         texts_for_ner: List[str] = []
 
-        # ---- Prepare TEIs ----
+        # ---- Prepare MDs ----
         for fname in os.listdir(out_dir):
             curie = fname.split(".")[0].replace("_", ":")
             job = ref_map.get(curie)
@@ -278,14 +278,14 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                 continue
 
             try:
-                tei = AllianceTEI()
-                tei.load_from_file(os.path.join(out_dir, fname))
+                md = AllianceMarkdown()
+                md.load_from_file(os.path.join(out_dir, fname))
             except Exception as e:
-                logger.warning("TEI load failed for %s: %s. Skipping.", curie, e)
+                logger.warning("MD load failed for %s: %s. Skipping.", curie, e)
                 continue
 
             try:
-                fulltext = tei.get_fulltext() or ""
+                fulltext = md.get_fulltext() or ""
             except Exception as e:
                 logger.error("Fulltext error for %s: %s. Marking failure.", curie, e)
                 set_job_started(job)
@@ -293,12 +293,12 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
                 continue
 
             try:
-                abstract = tei.get_abstract() or ""
+                abstract = md.get_abstract() or ""
             except Exception as e:
                 logger.warning("Abstract error for %s: %s. Ignoring.", curie, e)
                 abstract = ""
             try:
-                title = tei.get_title() or ""
+                title = md.get_title() or ""
             except Exception as e:
                 logger.warning("Title error for %s: %s. Ignoring.", curie, e)
                 title = ""
@@ -309,7 +309,7 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
             metas.append((curie, job, title, abstract, fulltext))
 
         if not texts_for_ner:
-            logger.info("No valid TEIs in this batch.")
+            logger.info("No valid MDs in this batch.")
             continue
 
         # ---- Run NER ----
@@ -377,8 +377,8 @@ def process_entity_extraction_jobs(mod_id, topic, jobs, test_mode: bool = False,
 def main():
     parser = argparse.ArgumentParser(description='Extract biological entities from documents')
     parser.add_argument(
-        "--combined-tei-dir", metavar="DIR",
-        help="Process every .combined.tei under this directory instead of downloading TEIs."
+        "--combined-md-dir", metavar="DIR",
+        help="Process every .md file under this directory instead of downloading MDs."
     )
     parser.add_argument("--refresh-taxa-cache", action="store_true",
                         help="Ignore on-disk parent/children cache and rebuild from NCBI API")
@@ -459,7 +459,7 @@ def main():
                 ner_batch_size=args.ner_batch,
                 prefilter=not args.no_prefilter,
                 log_every=args.log_every,
-                combined_tei_dir=args.combined_tei_dir,
+                combined_md_dir=args.combined_md_dir,
                 refresh_taxa_cache=args.refresh_taxa_cache,
             )
     finally:

--- a/agr_entity_extractor/fit_and_upload_tfidf_vectorizer.py
+++ b/agr_entity_extractor/fit_and_upload_tfidf_vectorizer.py
@@ -7,10 +7,10 @@ import dill
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from agr_entity_extractor.models import CustomTokenizer
-from utils.abc_utils import get_all_ref_curies, download_tei_files_for_references, \
+from utils.abc_utils import get_all_ref_curies, download_md_files_for_references, \
     upload_ml_model
 from utils.ateam_utils import get_all_curated_entities
-from utils.tei_utils import convert_all_tei_files_in_dir_to_txt
+from utils.md_utils import convert_all_md_files_in_dir_to_txt
 
 logger = logging.getLogger(__name__)
 
@@ -25,30 +25,30 @@ def fit_vectorizer_on_agr_corpus(mod_abbreviation: str = None, match_uppercase: 
             logger.info(f"{download_dir} has been wiped.")
             os.makedirs(download_dir, exist_ok=True)
 
-    tei_files_present = False
+    md_files_present = False
     txt_files_present = False
     if not continue_download:
         if os.path.exists(download_dir) and len(os.listdir(download_dir)) > 0:
-            tei_files_present = len([file for file in os.listdir(download_dir) if file.endswith(".tei")]) > 0
+            md_files_present = len([file for file in os.listdir(download_dir) if file.endswith(".md")]) > 0
             txt_files_present = len([file for file in os.listdir(download_dir) if file.endswith(".txt")]) > 0
 
-    if not tei_files_present and not txt_files_present:
+    if not md_files_present and not txt_files_present:
         if not continue_download:
-            logger.info("No TEI files found in the download directory. Downloading TEI files.")
+            logger.info("No MD files found in the download directory. Downloading MD files.")
         logger.info(f"Getting all reference curies for {mod_abbreviation} from the Alliance ABC API.")
         ref_curies = get_all_ref_curies(mod_abbreviation=mod_abbreviation)
-        logger.info(f"Downloading TEI files for {len(ref_curies)} references.")
+        logger.info(f"Downloading MD files for {len(ref_curies)} references.")
         if continue_download:
-            logger.info("Skipping download of TEI files that are already present.")
-            ref_curies_present = set(f.replace("_", ":")[:-4] for f in os.listdir(download_dir)
-                                     if f.endswith(".tei"))
+            logger.info("Skipping download of MD files that are already present.")
+            ref_curies_present = set(os.path.splitext(f)[0].replace("_", ":") for f in os.listdir(download_dir)
+                                     if f.endswith(".md"))
             ref_curies = list(set(ref_curies) - ref_curies_present)
-        download_tei_files_for_references(ref_curies, download_dir, mod_abbreviation=mod_abbreviation)
-        tei_files_present = True
+        download_md_files_for_references(ref_curies, download_dir, mod_abbreviation=mod_abbreviation)
+        md_files_present = True
 
-    if tei_files_present:
-        logger.info("TEI files found in the download directory. Converting TEI files to TXT files.")
-        convert_all_tei_files_in_dir_to_txt(download_dir)
+    if md_files_present:
+        logger.info("MD files found in the download directory. Converting MD files to TXT files.")
+        convert_all_md_files_in_dir_to_txt(download_dir)
 
     logger.info("Downloading list of curated genes and alleles from the Alliance ABC API and adding them to the "
                 "tokenizer.")
@@ -102,7 +102,7 @@ def main():
     parser.add_argument("-u", "--upload-to-alliance", action="store_true",
                         help="If set, uploads the vectorizer to the Alliance API")
     parser.add_argument("-c", "--continue-download", action="store_true",
-                        help="If set, the script will skip the download of TEI files that are already present.")
+                        help="If set, the script will skip the download of MD files that are already present.")
     parser.add_argument("--update-custom-tokenizer", action="store_true",
                         help="Update the custom tokenizer")
     args = parser.parse_args()

--- a/agr_entity_extractor/fit_and_upload_tfidf_vectorizer_fast.py
+++ b/agr_entity_extractor/fit_and_upload_tfidf_vectorizer_fast.py
@@ -14,11 +14,11 @@ from scipy.sparse import diags
 from agr_entity_extractor.models import CustomTokenizer
 from utils.abc_utils import (
     get_all_ref_curies,
-    download_tei_files_for_references,
+    download_md_files_for_references,
     upload_ml_model
 )
 from utils.ateam_utils import get_all_curated_entities
-from utils.tei_utils import convert_all_tei_files_in_dir_to_txt
+from utils.md_utils import convert_all_md_files_in_dir_to_txt
 
 logger = logging.getLogger(__name__)
 
@@ -47,32 +47,32 @@ def fit_vectorizer_on_agr_corpus(
         os.makedirs(download_dir, exist_ok=True)
         logger.info("Wipe complete.")
 
-    # Check for existing TEI/TXT
-    tei_present = False
+    # Check for existing MD/TXT
+    md_present = False
     txt_present = False
     if not continue_download and os.path.exists(download_dir):
         files = os.listdir(download_dir)
-        tei_present = any(f.endswith('.tei') for f in files)
+        md_present = any(f.endswith('.md') for f in files)
         txt_present = any(f.endswith('.txt') for f in files)
-        logger.info(f"Found TEI: {tei_present}, TXT: {txt_present}")
+        logger.info(f"Found MD: {md_present}, TXT: {txt_present}")
 
-    # Download TEIs if needed
-    if not tei_present and not txt_present:
-        logger.info("Downloading TEI files...")
+    # Download Markdown files (with TEI->MD fallback) if needed
+    if not md_present and not txt_present:
+        logger.info("Downloading Markdown files...")
         ref_curies = get_all_ref_curies(mod_abbreviation=mod_abbreviation)
         logger.info(f"References to download: {len(ref_curies)}")
         if continue_download:
-            present = {f.replace('_', ':')[:-4] for f in files if f.endswith('.tei')}
+            present = {os.path.splitext(f)[0].replace('_', ':') for f in files if f.endswith('.md')}
             ref_curies = [r for r in ref_curies if r not in present]
-            logger.info(f"Skipping already present TEIs, remaining: {len(ref_curies)}")
-        download_tei_files_for_references(ref_curies, download_dir, mod_abbreviation)
-        logger.info("TEI download complete.")
-        tei_present = True
+            logger.info(f"Skipping already present MDs, remaining: {len(ref_curies)}")
+        download_md_files_for_references(ref_curies, download_dir, mod_abbreviation)
+        logger.info("MD download complete.")
+        md_present = True
 
-    # Convert TEI to TXT
-    if tei_present and not txt_present:
-        logger.info("Converting TEI to TXT...")
-        convert_all_tei_files_in_dir_to_txt(download_dir)
+    # Convert MD to TXT
+    if md_present and not txt_present:
+        logger.info("Converting MD to TXT...")
+        convert_all_md_files_in_dir_to_txt(download_dir)
         logger.info("Conversion complete.")
 
     # Fetch curated entities

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,3 +91,4 @@ pubmed_parser @ git+https://github.com/titipata/pubmed_parser
 retry==0.9.2
 matplotlib
 agr-curation-api-client==0.8.0
+agr-abc-document-parsers==1.5.1

--- a/tests/agr_document_classifier/test_antibody_classifier_pipeline.py
+++ b/tests/agr_document_classifier/test_antibody_classifier_pipeline.py
@@ -1,8 +1,7 @@
 """Integration tests for the antibody string-matching classifier pipeline.
 
-Mocks all ABC API calls and the TEI loader. Exercises the per-job logic
-end-to-end: TEI text -> rule matches -> TET POST payload + workflow
-status calls.
+Mocks all ABC API calls and the Markdown loader. Exercises the per-job logic
+end-to-end: MD text -> rule matches -> TET POST payload + workflow status calls.
 """
 
 from unittest.mock import patch, MagicMock
@@ -16,13 +15,13 @@ def patched_pipeline():
     p = "agr_document_classifier.agr_antibody_string_matching_classifier"
     with patch(f"{p}.get_all_curated_entities") as m_genes, \
          patch(f"{p}.get_tet_source_id", return_value=42), \
-         patch(f"{p}.download_tei_files_for_references") as m_download, \
+         patch(f"{p}.download_md_files_for_references") as m_download, \
          patch(f"{p}.send_classification_tag_to_abc", return_value=True) as m_send, \
          patch(f"{p}.set_job_started", return_value=True) as m_started, \
          patch(f"{p}.set_job_success", return_value=True) as m_success, \
          patch(f"{p}.set_job_failure", return_value=True) as m_failure, \
-         patch(f"{p}.AllianceTEI") as m_tei_cls, \
-         patch(f"{p}.os.listdir", return_value=["AGRKB_101000000000001.tei"]), \
+         patch(f"{p}.AllianceMarkdown") as m_md_cls, \
+         patch(f"{p}.os.listdir", return_value=["AGRKB_101000000000001.md"]), \
          patch(f"{p}.os.remove"), \
          patch(f"{p}.os.makedirs"):
         m_genes.return_value = (["pdr-1", "unc-54"], {}, {})
@@ -33,7 +32,7 @@ def patched_pipeline():
             "started": m_started,
             "success": m_success,
             "failure": m_failure,
-            "tei_cls": m_tei_cls,
+            "md_cls": m_md_cls,
         }
 
 
@@ -41,15 +40,15 @@ def _job(curie="AGRKB:101000000000001"):
     return {"reference_curie": curie, "reference_workflow_tag_id": 999, "mod_id": 3}
 
 
-def _set_tei_text(mocks, sentences):
-    inst = mocks["tei_cls"].return_value
+def _set_md_text(mocks, sentences):
+    inst = mocks["md_cls"].return_value
     inst.load_from_file = MagicMock()
     inst.get_sentences = MagicMock(return_value=sentences)
 
 
 def test_positive_paper_emits_tet_with_sorted_note(patched_pipeline):
     from agr_document_classifier import agr_antibody_string_matching_classifier as pipe
-    _set_tei_text(patched_pipeline, [
+    _set_md_text(patched_pipeline, [
         "The antibody was raised against UNC-54.",
         "We also used anti-PDR-1 in some experiments.",
     ])
@@ -73,7 +72,7 @@ def test_positive_paper_emits_tet_with_sorted_note(patched_pipeline):
 
 def test_negative_paper_emits_negated_tet_without_note(patched_pipeline):
     from agr_document_classifier import agr_antibody_string_matching_classifier as pipe
-    _set_tei_text(patched_pipeline, [
+    _set_md_text(patched_pipeline, [
         "We bought a commercial reagent from Sigma.",
         "The animals were maintained at 20 degrees.",
     ])
@@ -85,9 +84,9 @@ def test_negative_paper_emits_negated_tet_without_note(patched_pipeline):
     patched_pipeline["success"].assert_called_once()
 
 
-def test_tei_parse_failure_marks_job_failed(patched_pipeline):
+def test_md_parse_failure_marks_job_failed(patched_pipeline):
     from agr_document_classifier import agr_antibody_string_matching_classifier as pipe
-    patched_pipeline["tei_cls"].return_value.load_from_file.side_effect = ValueError("bad TEI")
+    patched_pipeline["md_cls"].return_value.load_from_file.side_effect = ValueError("bad MD")
     pipe.process_antibody_jobs(topic="ATP:0000096", jobs=[_job()])
 
     patched_pipeline["failure"].assert_called_once()

--- a/tests/utils/test_download_md_files.py
+++ b/tests/utils/test_download_md_files.py
@@ -1,0 +1,250 @@
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from utils import abc_utils
+
+
+def _show_all_response(ref_files):
+    payload = json.dumps(ref_files).encode("utf-8")
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = payload
+    return cm
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_downloads_only_main_md_for_matching_mod(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    ref_files = [
+        # main MD for WB → should be downloaded
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 111,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        # supplement MD → must be skipped (include_supplements default=False)
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 222,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        # main MD but for a different MOD → must be skipped
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 333,
+            "referencefile_mods": [{"mod_abbreviation": "MGI"}],
+        },
+        # TEI file → unused when MD exists for the same MOD
+        {
+            "file_extension": "tei",
+            "file_class": "tei",
+            "referencefile_id": 444,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# Downloaded markdown"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:101000000000001"], tmp, "WB",
+        )
+
+        # Only one download call, and only for the matching main md.
+        assert mock_download.call_count == 1
+        called_ref = mock_download.call_args[0][0]
+        assert called_ref["referencefile_id"] == 111
+
+        out_path = os.path.join(tmp, "AGRKB_101000000000001.md")
+        assert os.path.exists(out_path)
+        with open(out_path, "rb") as fh:
+            assert fh.read() == b"# Downloaded markdown"
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_falls_back_to_tei_and_converts_when_no_main_md(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """When no main MD exists but a TEI is present, the function should
+    download the TEI bytes and convert them to MD via the shared library."""
+    ref_files = [
+        {
+            "file_extension": "tei",
+            "file_class": "tei",
+            "referencefile_id": 444,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    tei_bytes = b"<?xml version='1.0'?><TEI xmlns='http://www.tei-c.org/ns/1.0'/>"
+    mock_download.return_value = tei_bytes
+
+    with patch("agr_abc_document_parsers.convert_xml_to_markdown",
+               return_value="# Converted from TEI") as mock_convert:
+        with tempfile.TemporaryDirectory() as tmp:
+            abc_utils.download_md_files_for_references(
+                ["AGRKB:101000000000001"], tmp, "WB",
+            )
+
+            mock_convert.assert_called_once_with(tei_bytes, "tei")
+            out_path = os.path.join(tmp, "AGRKB_101000000000001.md")
+            assert os.path.exists(out_path)
+            with open(out_path, "r", encoding="utf-8") as fh:
+                assert fh.read() == "# Converted from TEI"
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_no_md_or_tei_writes_no_file(mock_download, _req, mock_urlopen, _tok):
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 999,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:101000000000001"], tmp, "WB",
+        )
+        assert mock_download.call_count == 0
+        assert os.listdir(tmp) == []
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_only_first_main_md_is_taken(mock_download, _req, mock_urlopen, _tok):
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 1,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 2,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# md"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(["AGRKB:1"], tmp, "WB")
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 1
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_supplements_downloaded_when_opted_in(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """include_supplements=True should also download every
+    converted_merged_supplement row for the same MOD, and supplements
+    must NOT be converted from any other format."""
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 1,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 11,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 12,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        # Wrong MOD supplement → must be skipped
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 99,
+            "referencefile_mods": [{"mod_abbreviation": "MGI"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+
+    def _fake_dl(ref):
+        return ("# main" if ref["referencefile_id"] == 1
+                else f"# supp {ref['referencefile_id']}").encode("utf-8")
+    mock_download.side_effect = _fake_dl
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:101000000000001"], tmp, "WB", include_supplements=True,
+        )
+
+        files = sorted(os.listdir(tmp))
+        assert files == [
+            "AGRKB_101000000000001.md",
+            "AGRKB_101000000000001.supp_1.md",
+            "AGRKB_101000000000001.supp_2.md",
+        ]
+        with open(os.path.join(tmp, "AGRKB_101000000000001.supp_1.md"), "rb") as fh:
+            assert fh.read() == b"# supp 11"
+        with open(os.path.join(tmp, "AGRKB_101000000000001.supp_2.md"), "rb") as fh:
+            assert fh.read() == b"# supp 12"
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_supplements_not_downloaded_by_default(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 1,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 11,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# main"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:1"], tmp, "WB",
+        )
+        assert os.listdir(tmp) == ["AGRKB_1.md"]
+        # Only the main MD download was called; supplement was skipped.
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 1

--- a/tests/utils/test_md_utils.py
+++ b/tests/utils/test_md_utils.py
@@ -1,0 +1,262 @@
+import os
+import tempfile
+import textwrap
+
+from utils.md_utils import AllianceMarkdown
+
+
+SAMPLE_MD = textwrap.dedent(
+    """\
+    # On the role of daf-16 in *C. elegans*
+
+    **Journal:** Cell
+
+    **DOI:** 10.1234/abc
+
+    ## Abstract
+
+    This paper studies the role of *daf-16* in **longevity**.
+
+    ## Introduction
+
+    The dauer pathway involves daf-2 and daf-16. See Figure 1.
+
+    **Figure 1.** Pathway diagram.
+
+    ## Results
+
+    daf-16 mutants are short-lived. See Table 1.
+
+    | Strain | Lifespan |
+    | --- | --- |
+    | WT | 20 |
+    | daf-16 | 12 |
+
+    **Table 1.** Lifespan data.
+
+    ## References
+
+    1. Doe, J. (2020) The pathway. *Nature*, 1(1), 1-2. doi:10.1/foo
+    2. Smith, K. (2019) Another paper. *Cell*, 5, 100-110.
+    """
+)
+
+
+def _write_md(content: str) -> str:
+    fh = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    try:
+        fh.write(content)
+    finally:
+        fh.close()
+    return fh.name
+
+
+def test_load_from_file_populates_document():
+    path = _write_md(SAMPLE_MD)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        assert md.doc is not None
+        assert md.raw_md is not None
+    finally:
+        os.unlink(path)
+
+
+def test_get_title_strips_markdown_formatting():
+    path = _write_md(SAMPLE_MD)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        # Italics in the title should be stripped.
+        assert md.get_title() == "On the role of daf-16 in C. elegans"
+    finally:
+        os.unlink(path)
+
+
+def test_get_abstract_returns_plain_text():
+    path = _write_md(SAMPLE_MD)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        abstract = md.get_abstract()
+        # Bold/italic markers must be gone.
+        assert "**" not in abstract
+        assert "*daf-16*" not in abstract
+        assert "daf-16" in abstract
+        assert "longevity" in abstract
+    finally:
+        os.unlink(path)
+
+
+def test_get_fulltext_excludes_references():
+    path = _write_md(SAMPLE_MD)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        ft = md.get_fulltext()
+        # Body content should be present.
+        assert "daf-16" in ft
+        assert "daf-2" in ft
+        assert "Lifespan" in ft  # table caption
+        assert "WT" in ft        # table cell
+        # References must not leak in.
+        assert "Doe, J." not in ft
+        assert "Smith, K." not in ft
+    finally:
+        os.unlink(path)
+
+
+def test_get_fulltext_excludes_supplements():
+    main_md = textwrap.dedent(
+        """\
+        # Main Paper
+
+        ## Abstract
+
+        Body of the main paper.
+        """
+    )
+    supplement_md = textwrap.dedent(
+        """\
+        SHOULD_NOT_APPEAR
+
+        Some supplemental content.
+        """
+    )
+    # Splice the supplement at the end of the main markdown the way the
+    # md_reader recognises it (currently the parser treats trailing content
+    # before sub-articles as part of the main doc; the supplements list is
+    # populated only when callers pass them via load_document_with_supplements,
+    # which we do not use). We still assert the AllianceMarkdown wrapper
+    # never includes ``doc.supplements`` content.
+    path = _write_md(main_md)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        # Manually attach a supplement Document to mimic what the loader
+        # would do if the caller asked for it.
+        from agr_abc_document_parsers import read_markdown
+        md.doc.supplements.append(read_markdown(supplement_md))
+        ft = md.get_fulltext()
+        assert "SHOULD_NOT_APPEAR" not in ft
+        assert "Body of the main paper." in ft
+    finally:
+        os.unlink(path)
+
+
+def test_get_sentences_returns_list_of_strings():
+    path = _write_md(SAMPLE_MD)
+    try:
+        md = AllianceMarkdown()
+        md.load_from_file(path)
+        sentences = md.get_sentences()
+        assert isinstance(sentences, list)
+        assert all(isinstance(s, str) for s in sentences)
+        assert any("daf-16 mutants are short-lived" in s for s in sentences)
+    finally:
+        os.unlink(path)
+
+
+def test_methods_handle_unloaded_state():
+    md = AllianceMarkdown()
+    assert md.get_title() == ""
+    assert md.get_abstract() == ""
+    assert md.get_fulltext() == ""
+    assert md.get_sentences() == []
+
+
+def test_load_from_file_handles_non_utf8_bytes():
+    # Latin-1 byte sequence that is not valid UTF-8.
+    raw = "# Café\n\n## Abstract\n\nBody.\n".encode("latin-1")
+    fh = tempfile.NamedTemporaryFile(suffix=".md", delete=False)
+    try:
+        fh.write(raw)
+        fh.close()
+        md = AllianceMarkdown()
+        md.load_from_file(fh.name)
+        # No exception; raw_md is decoded somehow and parsing succeeds.
+        assert md.raw_md is not None
+        assert md.doc is not None
+    finally:
+        os.unlink(fh.name)
+
+
+def test_load_with_supplements_auto_discovers_siblings(tmp_path):
+    """When include_supplements=True, sibling ``<basename>.supp_<N>.md`` files
+    are picked up and merged into the Document; their text appears in
+    get_fulltext output."""
+    main = tmp_path / "AGRKB_1.md"
+    main.write_text("# Main paper\n\n## Abstract\n\nMain abstract.\n", encoding="utf-8")
+    (tmp_path / "AGRKB_1.supp_1.md").write_text(
+        "## S1\n\nSUPP_ONE_BODY\n", encoding="utf-8")
+    (tmp_path / "AGRKB_1.supp_2.md").write_text(
+        "## S2\n\nSUPP_TWO_BODY\n", encoding="utf-8")
+    # Unrelated MD file in same dir — must NOT be loaded as a supplement.
+    (tmp_path / "AGRKB_2.md").write_text("# Other paper\n", encoding="utf-8")
+
+    md = AllianceMarkdown()
+    md.load_from_file(str(main), include_supplements=True)
+
+    assert md.has_supplements is True
+    assert len(md.doc.supplements) == 2
+    ft = md.get_fulltext()
+    assert "Main paper" in ft
+    assert "Main abstract" in ft
+    assert "SUPP_ONE_BODY" in ft
+    assert "SUPP_TWO_BODY" in ft
+    assert "Other paper" not in ft
+
+
+def test_load_with_supplements_default_is_off(tmp_path):
+    """Without include_supplements, sibling supp_*.md files are ignored."""
+    main = tmp_path / "AGRKB_1.md"
+    main.write_text("# Main paper\n\n## Abstract\n\nMain abstract.\n", encoding="utf-8")
+    (tmp_path / "AGRKB_1.supp_1.md").write_text(
+        "## S1\n\nSUPP_ONE_BODY\n", encoding="utf-8")
+
+    md = AllianceMarkdown()
+    md.load_from_file(str(main))
+
+    assert md.has_supplements is False
+    assert md.doc.supplements == []
+    ft = md.get_fulltext()
+    assert "Main paper" in ft
+    assert "SUPP_ONE_BODY" not in ft
+
+
+def test_explicit_supplement_paths(tmp_path):
+    """An explicit list of supplement_paths overrides auto-discovery."""
+    main = tmp_path / "AGRKB_1.md"
+    main.write_text("# Main paper\n\n## Abstract\n\nMain abstract.\n", encoding="utf-8")
+    explicit = tmp_path / "elsewhere.md"
+    explicit.write_text("## S\n\nEXPLICIT_BODY\n", encoding="utf-8")
+    # A discoverable supp file that should be ignored because we passed an
+    # explicit list.
+    (tmp_path / "AGRKB_1.supp_1.md").write_text(
+        "## S1\n\nDISCOVERABLE_BODY\n", encoding="utf-8")
+
+    md = AllianceMarkdown()
+    md.load_from_file(str(main), supplement_paths=[str(explicit)])
+
+    assert md.has_supplements is True
+    ft = md.get_fulltext()
+    assert "EXPLICIT_BODY" in ft
+    assert "DISCOVERABLE_BODY" not in ft
+
+
+def test_convert_all_md_files_in_dir_skips_supplements(tmp_path):
+    """The dir->txt converter must not produce a separate .txt for each
+    supplement; supplements are consumed alongside their main file."""
+    from utils.md_utils import convert_all_md_files_in_dir_to_txt
+
+    (tmp_path / "AGRKB_1.md").write_text(
+        "# Main\n\n## Abstract\n\nMain body.\n", encoding="utf-8")
+    (tmp_path / "AGRKB_1.supp_1.md").write_text(
+        "## S\n\nSupp body.\n", encoding="utf-8")
+
+    convert_all_md_files_in_dir_to_txt(str(tmp_path))
+
+    files = sorted(p.name for p in tmp_path.iterdir())
+    assert "AGRKB_1.txt" in files
+    # No txt for the supplement.
+    assert "AGRKB_1.supp_1.txt" not in files

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -637,6 +637,245 @@ def download_tei_files_for_references(reference_curies: List[str], output_dir: s
     logger.info("Finished downloading TEI files")
 
 
+def request_conversion_for_reference(reference_curie: str,
+                                     poll_interval_seconds: float = 15.0,
+                                     timeout_seconds: float = 1200.0,
+                                     wait_for_supplements: bool = False) -> str:
+    """Trigger and poll the ABC on-demand conversion endpoint for ``reference_curie``.
+
+    Calls ``GET /reference/referencefile/conversion_request/{curie}`` and polls
+    every ``poll_interval_seconds`` until a terminal condition is reached.
+
+    Returns one of:
+
+    * ``converted`` — the main MD row is now in ABC. When
+      ``wait_for_supplements`` is False (the default), this is returned as
+      soon as ``converted_merged_main`` appears in ``converted_classes``,
+      *even if* the overall job is still running because supplement
+      conversion is in progress server-side. When ``wait_for_supplements``
+      is True, this is only returned once the overall job status is
+      ``converted`` (i.e. main + every supplement done).
+    * ``failed`` — the job failed or the API call errored out.
+    * ``no_sources`` — the reference has nothing to convert.
+    * ``timeout`` — the deadline elapsed before a terminal status was
+      reached.
+    """
+    url = f"{blue_api_base_url}/reference/referencefile/conversion_request/{reference_curie}"
+    deadline = time.monotonic() + timeout_seconds
+    last_status = "unknown"
+    first_call = True
+    while True:
+        token = get_authentication_token()
+        headers = generate_headers(token)
+        try:
+            resp = requests.get(url, headers=headers, timeout=60)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Conversion request HTTP error for {reference_curie}: {e}")
+            return "failed"
+
+        if resp.status_code in (200, 202):
+            try:
+                body = resp.json()
+            except ValueError:
+                logger.error(f"Conversion request returned non-JSON for {reference_curie}: "
+                             f"{resp.text[:200]}")
+                return "failed"
+            last_status = body.get("status", "unknown")
+            converted_classes = body.get("converted_classes", []) or []
+            if first_call:
+                logger.info(f"Conversion request for {reference_curie}: status={last_status}, "
+                            f"job_id={body.get('job_id')}")
+                first_call = False
+            if last_status in ("converted", "failed", "no_sources"):
+                return last_status
+            # status == "running"
+            if not wait_for_supplements and "converted_merged_main" in converted_classes:
+                logger.info(
+                    f"Main MD ready for {reference_curie}; supplement conversion continues "
+                    f"in the background server-side"
+                )
+                return "converted"
+        else:
+            logger.error(f"Conversion request for {reference_curie} returned "
+                         f"HTTP {resp.status_code}: {resp.text[:200]}")
+            return "failed"
+
+        if time.monotonic() >= deadline:
+            logger.warning(f"Conversion request for {reference_curie} timed out after "
+                           f"{timeout_seconds:.0f}s (last status: {last_status})")
+            return "timeout"
+        time.sleep(poll_interval_seconds)
+
+
+def download_md_files_for_references(reference_curies: List[str], output_dir: str, mod_abbreviation,
+                                     include_supplements: bool = False,
+                                     request_conversion: bool = False):
+    """Download main-document Markdown files for the given references.
+
+    Resolution order for the main file, per curie:
+
+    1. ``file_class == "converted_merged_main"``, ``file_extension == "md"``
+       — fetched directly.
+    2. ``file_class == "tei"``, ``file_extension == "tei"`` — fetched and
+       converted in-process via
+       :func:`agr_abc_document_parsers.convert_xml_to_markdown`.
+    3. (Only when ``request_conversion`` is True) trigger server-side
+       conversion via
+       ``GET /reference/referencefile/conversion_request/{curie}``, poll
+       until the job terminates, then re-fetch the resulting MD row from
+       ABC. This replaces the older local-Grobid PDF→TEI→MD path.
+
+    When ``include_supplements`` is True, also download every available
+    ``converted_merged_supplement`` MD row for the same MOD. Supplements are
+    *not* converted from any other format — if a supplement is not stored
+    as MD it is skipped. Supplement files are written alongside the main
+    file as ``<curie>.supp_<N>.md``.
+
+    All output files are named ``<curie>.md`` (main) or
+    ``<curie>.supp_<N>.md`` (supplements).
+    """
+    logger.info(
+        "Started downloading Markdown files (with TEI->MD fallback%s%s)",
+        ", server-side conversion fallback" if request_conversion else "",
+        ", supplements included" if include_supplements else "",
+    )
+    os.makedirs(output_dir, exist_ok=True)
+    for reference_curie in reference_curies:
+        main_written = _try_download_main_md(
+            reference_curie, output_dir, mod_abbreviation,
+        )
+
+        if not main_written and request_conversion:
+            logger.info(f"No MD/TEI for {reference_curie}; requesting on-demand conversion")
+            conv_status = request_conversion_for_reference(
+                reference_curie, wait_for_supplements=include_supplements,
+            )
+            if conv_status == "converted":
+                main_written = _try_download_main_md(
+                    reference_curie, output_dir, mod_abbreviation,
+                )
+                if not main_written:
+                    logger.error(
+                        f"{reference_curie}: conversion reported converted but main MD "
+                        f"still not available for MOD={mod_abbreviation}"
+                    )
+            else:
+                logger.warning(
+                    f"{reference_curie}: on-demand conversion ended with status={conv_status}"
+                )
+
+        if not main_written:
+            logger.warning(f"No main MD or TEI file available for {reference_curie}")
+            continue
+
+        if include_supplements:
+            _download_main_md_supplements(
+                reference_curie, output_dir, mod_abbreviation,
+            )
+
+    logger.info("Finished downloading Markdown files")
+
+
+def _show_all_for_reference(reference_curie: str) -> Optional[list]:
+    """Fetch and return the JSON list from ``/reference/referencefile/show_all/{curie}``,
+    or None on failure."""
+    token = get_authentication_token()
+    headers = generate_headers(token)
+    url = f'{blue_api_base_url}/reference/referencefile/show_all/{reference_curie}'
+    request = urllib.request.Request(url=url, headers=headers)
+    request.add_header("Content-type", "application/json")
+    request.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf8"))
+    except HTTPError as e:
+        logger.error(e)
+        return None
+
+
+def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviation: str) -> bool:
+    """Try to write a ``<curie>.md`` file using the main MD row first, then a
+    TEI-row fallback converted in-process. Returns True iff a file was written.
+    """
+    from agr_abc_document_parsers import convert_xml_to_markdown
+
+    resp_obj = _show_all_for_reference(reference_curie)
+    if resp_obj is None:
+        return False
+
+    base_name = reference_curie.replace(":", "_")
+    out_path = os.path.join(output_dir, base_name + ".md")
+
+    md_ref_file = next(
+        (rf for rf in resp_obj
+         if rf.get("file_extension") == "md"
+         and rf.get("file_class") == "converted_merged_main"
+         and any(m.get("mod_abbreviation") == mod_abbreviation
+                 for m in rf.get("referencefile_mods", []))),
+        None,
+    )
+    if md_ref_file is not None:
+        content = get_file_from_abc_reffile_obj(md_ref_file)
+        if content:
+            with open(out_path, "wb") as out_file:
+                out_file.write(content)
+            return True
+        logger.error(f"Main MD entry exists but download returned no bytes for {reference_curie}")
+
+    tei_ref_file = next(
+        (rf for rf in resp_obj
+         if rf.get("file_extension") == "tei"
+         and rf.get("file_class") == "tei"
+         and any(m.get("mod_abbreviation") == mod_abbreviation
+                 for m in rf.get("referencefile_mods", []))),
+        None,
+    )
+    if tei_ref_file is None:
+        return False
+
+    tei_bytes = get_file_from_abc_reffile_obj(tei_ref_file)
+    if not tei_bytes:
+        logger.error(f"TEI download returned no bytes for {reference_curie}")
+        return False
+    try:
+        md_text = convert_xml_to_markdown(tei_bytes, "tei")
+    except Exception as e:
+        logger.error(f"Failed to convert TEI to MD for {reference_curie}: {e}")
+        return False
+    with open(out_path, "w", encoding="utf-8") as out_file:
+        out_file.write(md_text)
+    return True
+
+
+def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abbreviation: str) -> None:
+    """Download every ``converted_merged_supplement`` MD row for ``mod_abbreviation``
+    and write them as ``<curie>.supp_<N>.md`` (numbered in API order).
+    """
+    resp_obj = _show_all_for_reference(reference_curie)
+    if resp_obj is None:
+        return
+
+    base_name = reference_curie.replace(":", "_")
+    supp_ref_files = [
+        rf for rf in resp_obj
+        if rf.get("file_extension") == "md"
+        and rf.get("file_class") == "converted_merged_supplement"
+        and any(m.get("mod_abbreviation") == mod_abbreviation
+                for m in rf.get("referencefile_mods", []))
+    ]
+    for idx, supp in enumerate(supp_ref_files, start=1):
+        supp_bytes = get_file_from_abc_reffile_obj(supp)
+        if not supp_bytes:
+            logger.error(
+                f"Supplement MD entry exists but download returned no bytes "
+                f"for {reference_curie} (supp_{idx})"
+            )
+            continue
+        supp_path = os.path.join(output_dir, f"{base_name}.supp_{idx}.md")
+        with open(supp_path, "wb") as out_file:
+            out_file.write(supp_bytes)
+
+
 def convert_pdf_with_grobid(file_content):
     grobid_api_url = os.environ.get("GROBID_API_URL",
                                     "https://grobid.alliancegenome.org/api/processFulltextDocument")

--- a/utils/get_documents.py
+++ b/utils/get_documents.py
@@ -1,17 +1,13 @@
 import glob
 import os
 import logging
-from pathlib import Path
 from typing import Tuple, List
-from grobid_client import Client
-from grobid_client.api.pdf import process_fulltext_document
-from grobid_client.models import Article, ProcessForm
-from grobid_client.types import TEI, File
+
 import nltk
 from nltk import word_tokenize
 from nltk.corpus import stopwords
 
-from utils.tei_utils import get_sentences_from_tei_section
+from utils.md_utils import AllianceMarkdown
 
 # Download required NLTK data
 nltk.download('stopwords')
@@ -22,43 +18,31 @@ logger = logging.getLogger(__name__)
 
 
 def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
-    documents = []
-    client = None
+    """Load every parseable Markdown document in ``input_docs_dir`` as
+    ``(file_path, fulltext, title, abstract)``.
+
+    Only ``.md`` files are read. Markdown files are produced upstream by
+    :func:`utils.abc_utils.download_md_files_for_references`, which fetches
+    the converted main MD from ABC, falls back to a TEI→MD library
+    conversion, and (optionally) requests on-demand server-side conversion
+    via the ``/reference/referencefile/conversion_request`` endpoint when
+    no MD or TEI is yet available in ABC.
+    """
+    documents: List[Tuple[str, str, str, str]] = []
     for file_path in glob.glob(os.path.join(input_docs_dir, "*")):
-        num_errors = 0
-        file_obj = Path(file_path)
-        if file_path.endswith(".tei") or file_path.endswith(".pdf"):
-            with file_obj.open("rb") as fin:
-                if file_path.endswith(".pdf"):
-                    if client is None:
-                        client = Client(base_url=os.environ.get("GROBID_API_URL"), timeout=1000, verify_ssl=False)
-                    logger.info("Started pdf to TEI conversion")
-                    form = ProcessForm(
-                        segment_sentences="1",
-                        input_=File(file_name=file_obj.name, payload=fin, mime_type="application/pdf"))
-                    r = process_fulltext_document.sync_detailed(client=client, multipart_data=form)
-                    file_stream = r.content
-                else:
-                    file_stream = fin
-                try:
-                    article: Article = TEI.parse(file_stream, figures=True)
-                except Exception:
-                    num_errors += 1
-                    continue
-                sentences = []
-                for section in article.sections:
-                    sec_sentences, sec_num_errors = get_sentences_from_tei_section(section)
-                    sentences.extend(sec_sentences)
-                    num_errors += sec_num_errors
-                abstract = ""
-                for section in article.sections:
-                    if section.name == "ABSTRACT":
-                        abs_sentences, num_errors = get_sentences_from_tei_section(section)
-                        abstract = " ".join(abs_sentences)
-                        break
-                documents.append((file_path, " ".join(sentences), article.title, abstract))
-        if num_errors > 0:
-            logger.debug(f"Couldn't read {str(num_errors)} sentence(s) from {str(file_path)}")
+        if not file_path.endswith(".md"):
+            continue
+        # Skip supplement files that share the dir; they're consumed via
+        # AllianceMarkdown.load_from_file(..., include_supplements=True) on
+        # the main file when callers opt in.
+        if ".supp_" in os.path.basename(file_path):
+            continue
+        try:
+            md = AllianceMarkdown()
+            md.load_from_file(file_path)
+            documents.append((file_path, md.get_fulltext(), md.get_title(), md.get_abstract()))
+        except Exception as e:
+            logger.warning(f"Failed to parse Markdown {file_path}: {e}")
     return documents
 
 

--- a/utils/md_utils.py
+++ b/utils/md_utils.py
@@ -1,0 +1,226 @@
+import glob
+import logging
+import os
+import re
+
+from agr_abc_document_parsers import (
+    Document,
+    extract_abstract_text,
+    extract_plain_text,
+    extract_sentences,
+    load_document_with_supplements,
+    read_markdown,
+    strip_markdown_formatting,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Entity-token regex + filter ported from utils/tei_utils.py for the
+# "include_attributes" allele-extraction path. We mine the entire MD
+# (including references) for letter+digit identifiers that look like
+# biological entity names — replicates the spirit of the old TEI
+# attribute mining, minus the XML-attribute-only IDs which don't exist
+# in Markdown. The XML-attribute-junk filters (b#### bib IDs, e### page
+# codes inside biblScope) are dropped because their TEI-only triggers
+# don't apply.
+_ENTITY_TOKEN_RE = re.compile(r'[A-Za-z][A-Za-z0-9_.\-]*\d+[A-Za-z0-9_.\-]*')
+_ROMAN_NUMERAL_RE = re.compile(r'^[ivx]+$')
+_BAD_ENTITY_PREFIXES = ('fig', 'sup', 'sub', 'sec', 'eq', 'lt', 'gt', 'amp')
+
+
+def _looks_like_entity(tok: str) -> bool:
+    tok = tok.strip()
+    if len(tok) < 2:
+        return False
+    has_letter = any(c.isalpha() for c in tok)
+    has_digit = any(c.isdigit() for c in tok)
+    if not (has_letter and has_digit):
+        return False
+    lowered = tok.lower()
+    if lowered.startswith(_BAD_ENTITY_PREFIXES):
+        return False
+    if _ROMAN_NUMERAL_RE.fullmatch(lowered):
+        return False
+    return True
+
+
+def _mine_entity_tokens(text: str) -> list[str]:
+    """Return sorted, deduped entity-like tokens scraped from ``text``."""
+    tokens = {tok for tok in _ENTITY_TOKEN_RE.findall(text or "") if _looks_like_entity(tok)}
+    return sorted(tokens)
+
+
+def _read_md_text(path: str) -> str:
+    with open(path, "rb") as f:
+        raw_bytes = f.read()
+    try:
+        return raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw_bytes.decode("latin-1", errors="replace")
+
+
+def _discover_supplement_paths(main_path: str) -> list[str]:
+    """Return sibling ``<basename>.supp_*.md`` files for a given main MD path,
+    sorted by the numeric ``N`` in ``supp_<N>``.
+    """
+    directory = os.path.dirname(main_path) or "."
+    base = os.path.basename(main_path)
+    if not base.endswith(".md"):
+        return []
+    stem = base[: -len(".md")]
+    pattern = os.path.join(directory, f"{stem}.supp_*.md")
+
+    def _key(p: str) -> tuple[int, str]:
+        name = os.path.basename(p)
+        try:
+            num = int(name[len(stem) + len(".supp_"):-len(".md")])
+        except ValueError:
+            num = 10**9
+        return (num, name)
+
+    return sorted(glob.glob(pattern), key=_key)
+
+
+class AllianceMarkdown:
+    """Wrapper around an ABC-format Markdown document.
+
+    Provides the same surface as ``AllianceTEI`` (``load_from_file``,
+    ``get_title``, ``get_abstract``, ``get_fulltext``, ``get_sentences``)
+    so it can be used as a drop-in replacement for downstream pipelines
+    that previously consumed TEI.
+
+    The underlying parser is :func:`agr_abc_document_parsers.read_markdown`,
+    which builds a ``Document`` model from the ABC Markdown format. Plain
+    text generation goes through :func:`extract_plain_text` whose defaults
+    already exclude the reference list — matching the existing TEI
+    behaviour.
+
+    Supplements are off by default. Call ``load_from_file(path,
+    include_supplements=True)`` (or pass an explicit ``supplement_paths``
+    list) to also pull sibling ``<basename>.supp_*.md`` files into the
+    Document; they are then included in :meth:`get_fulltext` and
+    :meth:`get_sentences` output.
+    """
+
+    def __init__(self):
+        self.doc: Document | None = None
+        self.raw_md: str | None = None
+        self.has_supplements: bool = False
+
+    def load_from_file(self, file_path: str, include_supplements: bool = False,
+                       supplement_paths: list[str] | None = None):
+        """Load a main MD file. When ``include_supplements`` is True (or
+        ``supplement_paths`` is provided), also load supplemental MD files
+        and merge them into the resulting Document.
+        """
+        self.raw_md = _read_md_text(file_path)
+
+        paths = list(supplement_paths) if supplement_paths is not None else (
+            _discover_supplement_paths(file_path) if include_supplements else []
+        )
+
+        if paths:
+            supp_texts = [_read_md_text(p) for p in paths]
+            self.doc = load_document_with_supplements(self.raw_md, supp_texts)
+            self.has_supplements = True
+        else:
+            self.doc = read_markdown(self.raw_md)
+            self.has_supplements = False
+
+    def get_title(self) -> str:
+        if not self.doc or not self.doc.title:
+            return ""
+        return strip_markdown_formatting(self.doc.title).strip()
+
+    def get_abstract(self) -> str:
+        if not self.doc:
+            return ""
+        return extract_abstract_text(self.doc).strip()
+
+    def get_fulltext(self, include_attributes: bool = False, **kwargs) -> str:
+        """Return the document fulltext.
+
+        Any keyword argument accepted by
+        :func:`agr_abc_document_parsers.extract_plain_text` is forwarded as-is,
+        so callers can toggle every section the library knows about
+        (``include_authors``, ``include_correspondence``, ``include_metadata``,
+        ``include_abstract``, ``include_keywords``, ``include_body``,
+        ``include_acknowledgments``, ``include_funding``, ``include_author_notes``,
+        ``include_competing_interests``, ``include_data_availability``,
+        ``include_back_matter``, ``include_references``, ``include_supplements``,
+        ``include_sub_articles``).
+
+        Defaults match the library: title is always present; abstract, body,
+        acknowledgments, funding, author-notes, competing-interests,
+        data-availability, back-matter and supplements are on; authors,
+        correspondence, metadata, keywords, references and sub-articles are off.
+        ``include_supplements`` defaults to ``self.has_supplements`` unless the
+        caller passes it explicitly.
+
+        ``include_attributes=True`` additionally appends entity-like tokens
+        (letter+digit identifiers) mined from the entire Markdown — body plus
+        references — replicating the allele-extraction TEI behaviour. This is
+        only useful for the allele topic where downstream NER benefits from
+        seeing identifiers that may live in citation entries. Note that
+        switching it on forces ``include_references=True`` for the underlying
+        regex sweep, but the formatted reference list is *not* added to the
+        textual output unless the caller also passes ``include_references=True``
+        explicitly.
+        """
+        if not self.doc:
+            return ""
+        kwargs.setdefault("include_supplements", self.has_supplements)
+        text = extract_plain_text(self.doc, **kwargs).strip()
+        if include_attributes:
+            kwargs_for_mining = dict(kwargs)
+            kwargs_for_mining["include_references"] = True
+            mined_source = extract_plain_text(self.doc, **kwargs_for_mining)
+            tokens = _mine_entity_tokens(mined_source)
+            if tokens:
+                appended = ". ".join(tokens) + "."
+                text = (text + " " + appended).strip() if text else appended
+        return text
+
+    def get_sentences(self, include_supplements: bool | None = None) -> list[str]:
+        """Return sentences from the document.
+
+        Mirrors the underlying library, which only exposes
+        ``include_supplements`` for sentence splitting (it always uses the
+        full default body for the underlying text). Pass an explicit value
+        to override; otherwise defaults to ``self.has_supplements``.
+
+        Callers who need sentences with custom section toggles should split
+        the output of :meth:`get_fulltext` directly.
+        """
+        if not self.doc:
+            return []
+        if include_supplements is None:
+            include_supplements = self.has_supplements
+        return extract_sentences(self.doc, include_supplements=include_supplements)
+
+
+def convert_all_md_files_in_dir_to_txt(dir_path: str, include_supplements: bool = False):
+    """Convert every main ``.md`` file in ``dir_path`` to a sibling ``.txt``
+    containing its fulltext.
+
+    ``.supp_*.md`` files are skipped here — they're picked up automatically
+    when ``include_supplements`` is True.
+    """
+    for fname in os.listdir(dir_path):
+        if not fname.endswith(".md"):
+            continue
+        # Skip supplement files; they're consumed alongside their main file.
+        stem = fname[: -len(".md")]
+        if ".supp_" in stem:
+            continue
+        md_file = os.path.join(dir_path, fname)
+        try:
+            md = AllianceMarkdown()
+            md.load_from_file(md_file, include_supplements=include_supplements)
+            article_text = md.get_fulltext()
+            txt_path = md_file[: -len(".md")] + ".txt"
+            with open(txt_path, "w", encoding="utf-8") as out:
+                out.write(article_text)
+        except Exception as e:
+            logger.error(f"Error parsing Markdown file {md_file}: {e}")


### PR DESCRIPTION
## Summary

- Adopt the `agr-abc-document-parsers` library as the source of document text. New `AllianceMarkdown` wrapper (`utils/md_utils.py`) exposes `get_title` / `get_abstract` / `get_fulltext` / `get_sentences`, supports merging sibling `<basename>.supp_*.md` supplements, forwards section-toggle kwargs to `extract_plain_text`, and provides an allele-flavoured `include_attributes` regex sweep that replicates the old TEI attribute-mining behaviour.
- `download_md_files_for_references` now resolves each reference via main MD → in-process TEI→MD library conversion → on-demand server-side conversion (`/reference/referencefile/conversion_request`). The local Grobid PDF→TEI→MD path is removed (Grobid is being decommissioned). The conversion poller short-circuits on `converted_merged_main` when the caller does not need supplements.
- All non-BERT consumers — entity extraction, species extraction, antibody string-matching classifier, topic classifier, priority classifier, embedding-matrix builder, TF-IDF vectorizer training, trainer — now consume `.md` files via `AllianceMarkdown`. `agr_entity_extraction_pipeline` opts into `include_keywords=True`. BERT entity extractor is intentionally untouched.

## Test plan

- [ ] `pytest tests/` — new suites `tests/utils/test_md_utils.py` and `tests/utils/test_download_md_files.py` should pass alongside the existing tests.
- [ ] `make run-local-flake8` and `make run-local-mypy` clean.
- [ ] Smoke-test `agr_document_classifier_classify.py --test_mode` against a small batch of WB references on the stage ABC server.
- [ ] Smoke-test `agr_entity_extraction_pipeline.py` on a small batch to confirm Markdown ingestion flows end to end.
- [ ] Verify supplement merging on at least one reference known to have `supp_*.md` files (e.g. via `AllianceMarkdown.load_from_file(..., include_supplements=True)`).
- [ ] Confirm no Grobid dependency remains in any pipeline path exercised above.