### PR TITLE
feat(bin): bootstrap and upgrade SVN working copy from inside the container

### DIFF
--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -8,14 +8,17 @@
 #
 #   30 13 * * * docker run --rm \
 #     -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
+#     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
-#     -v "$HOME/.subversion:/root/.subversion" \
 #     agr_document_classifier \
 #     ./bin/check_textmining_freshness.sh
 #
 # Required env vars:
 #   SVN_REPO_URL                                   - parent URL of the
 #                                                    textmining_*.txt files
+#   SVN_USERNAME, SVN_PASSWORD                     - passed to svn as
+#                                                    --username/--password
+#                                                    --no-auth-cache
 #   CRONTAB_EMAIL, SENDER_EMAIL, SENDER_PASSWORD   - for alert dispatch
 #
 # Optional:
@@ -32,6 +35,9 @@ if [[ -z "${SVN_REPO_URL:-}" ]]; then
     echo "ERROR: SVN_REPO_URL must be set" >&2
     exit 0
 fi
+: "${SVN_USERNAME:?SVN_USERNAME must be set}"
+: "${SVN_PASSWORD:?SVN_PASSWORD must be set}"
+SVN_AUTH=(--non-interactive --no-auth-cache --username "$SVN_USERNAME" --password "$SVN_PASSWORD")
 
 STALE_THRESHOLD_DAYS="${STALE_THRESHOLD_DAYS:-3}"
 
@@ -48,7 +54,7 @@ stale_report=""
 
 for f in "${FILES[@]}"; do
     url="${SVN_REPO_URL%/}/$f"
-    iso=$(svn info --show-item last-changed-date "$url" 2>/dev/null | tr -d '[:space:]')
+    iso=$(svn "${SVN_AUTH[@]}" info --show-item last-changed-date "$url" 2>/dev/null | tr -d '[:space:]')
     if [[ -z "$iso" ]]; then
         stale_report+="MISSING/UNREADABLE: $url"$'\n'
         continue

--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -1,28 +1,38 @@
 #!/usr/bin/env bash
-# Daily freshness check for the four FB ABC textmining output files.
-# If any file's mtime is older than STALE_THRESHOLD_DAYS (default 3), emails curators.
+# Daily freshness check for the four FB ABC textmining output files in SVN.
+# If any file's last commit is older than STALE_THRESHOLD_DAYS (default 3),
+# emails curators.
 #
-# Designed to run as a cron entry on the FlyBase GoCD agent (which is the only
-# place that can stat the real SVN working copy directly).
+# Designed to run inside the agr_document_classifier container so it has access
+# to svn 1.14 and to send_report. The cron entry on the GoCD agent should be:
 #
-# Optional env vars:
-#   CURATION_STATUS_DIR     host path of the SVN working copy. Defaults to
-#                           "$PWD/curation_status" — set this in the cron entry
-#                           by `cd`-ing into the pipeline working directory
-#                           first (the agent name is part of the path so it
-#                           can't sensibly be hardcoded), e.g.:
-#                             30 13 * * * cd /var/go/<agent>/pipelines/ExportFBClassifiers && /var/go/.../bin/check_textmining_freshness.sh
+#   30 13 * * * docker run --rm \
+#     -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
+#     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
+#     -v "$HOME/.subversion:/root/.subversion" \
+#     agr_document_classifier \
+#     ./bin/check_textmining_freshness.sh
+#
+# Required env vars:
+#   SVN_REPO_URL                                   - parent URL of the
+#                                                    textmining_*.txt files
+#   CRONTAB_EMAIL, SENDER_EMAIL, SENDER_PASSWORD   - for alert dispatch
+#
+# Optional:
 #   STALE_THRESHOLD_DAYS    age cutoff in days (default: 3)
 #
-# Always exits 0 — alerting is the side effect; we don't want a stale-files alarm
-# to also fail the cron entry itself.
+# Always exits 0 — alerting is the side effect; we don't want a stale-files
+# alarm to also fail the cron entry itself.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Capture $PWD before any cd; lets the cron entry control the working copy
-# location simply by `cd`-ing into the pipeline directory first.
-CURATION_STATUS_DIR="${CURATION_STATUS_DIR:-$PWD/curation_status}"
+
+if [[ -z "${SVN_REPO_URL:-}" ]]; then
+    echo "ERROR: SVN_REPO_URL must be set" >&2
+    exit 0
+fi
+
 STALE_THRESHOLD_DAYS="${STALE_THRESHOLD_DAYS:-3}"
 
 FILES=(
@@ -30,38 +40,29 @@ FILES=(
     "textmining_negative_ABC.txt"
     "textmining_positive_ABC_using_score.txt"
     "textmining_negative_ABC_using_score.txt"
-    ".last_success"
 )
 
-# stat varies between GNU (Linux) and BSD (macOS); try both.
-file_mtime() {
-    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
-}
-
-format_epoch() {
-    date -u -d "@$1" +%FT%TZ 2>/dev/null || date -u -r "$1" +%FT%TZ 2>/dev/null
-}
-
 threshold_seconds=$(( STALE_THRESHOLD_DAYS * 86400 ))
-now_epoch=$(date +%s)
+now_epoch=$(date -u +%s)
 stale_report=""
 
 for f in "${FILES[@]}"; do
-    path="$CURATION_STATUS_DIR/$f"
-    if [[ ! -e "$path" ]]; then
-        stale_report+="MISSING: $path"$'\n'
+    url="${SVN_REPO_URL%/}/$f"
+    iso=$(svn info --show-item last-changed-date "$url" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$iso" ]]; then
+        stale_report+="MISSING/UNREADABLE: $url"$'\n'
         continue
     fi
-    mtime=$(file_mtime "$path")
+    # svn emits e.g. 2026-05-14T12:48:26.123456Z; GNU date handles that directly.
+    mtime=$(date -u -d "$iso" +%s 2>/dev/null)
     if [[ -z "$mtime" ]]; then
-        stale_report+="UNREADABLE: $path"$'\n'
+        stale_report+="UNPARSEABLE DATE for $url: $iso"$'\n'
         continue
     fi
     age=$(( now_epoch - mtime ))
     if (( age > threshold_seconds )); then
         days=$(( age / 86400 ))
-        human=$(format_epoch "$mtime")
-        stale_report+="STALE (${days}d old, last modified $human): $path"$'\n'
+        stale_report+="STALE (${days}d old, last commit $iso): $url"$'\n'
     fi
 done
 
@@ -69,15 +70,15 @@ if [[ -z "$stale_report" ]]; then
     exit 0
 fi
 
-body="The following FB ABC textmining files in $CURATION_STATUS_DIR on $(hostname)
-have not been refreshed within the last $STALE_THRESHOLD_DAYS days.
+body="The following FB ABC textmining files under $SVN_REPO_URL
+have not been re-committed within the last $STALE_THRESHOLD_DAYS days.
 The ExportFBClassifiers pipeline may be wedged.
 
 $stale_report
 Suggested checks:
   * GoCD pipeline 'ExportFBClassifiers' run history
-  * svn status in $CURATION_STATUS_DIR (look for 'C' entries)
-  * Latest run_export_and_commit.sh log on this agent"
+  * Latest run_export_and_commit.sh log on the agent
+  * svn log -l 5 $SVN_REPO_URL"
 
 if ! python3 "$SCRIPT_DIR/_send_report_shim.py" \
         "FB ABC textmining files are stale (>${STALE_THRESHOLD_DAYS}d)" \

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -2,12 +2,18 @@
 # Self-healing wrapper for the FlyBase ABC textmining export + SVN commit step.
 #
 # This script is intended to run INSIDE the agr_document_classifier container.
-# The GoCD task should `docker run` the image with the SVN working copy bind-
-# mounted at /curation_status and the agent's ~/.subversion/ at /root/.subversion/,
-# e.g.:
+# The container owns the SVN working copy end-to-end: it checks it out on first
+# run, updates it on subsequent runs, and commits back. GoCD must NOT also fetch
+# the SVN repo as a pipeline material into the same path, or the agent's svn
+# version may rewrite the working copy in an incompatible format.
+#
+# The GoCD task should `docker run` the image with a persistent host directory
+# bind-mounted at /curation_status and the agent's ~/.subversion/ at
+# /root/.subversion/, e.g.:
 #
 #   docker run --rm \
 #     -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
+#     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
 #     -e CURATION_STATUS_DIR=/curation_status \
 #     -v "$PWD/curation_status:/curation_status" \
 #     -v "$HOME/.subversion:/root/.subversion" \
@@ -15,14 +21,17 @@
 #     ./bin/run_export_and_commit.sh
 #
 # Flow:
-#   1. svn update; auto-resolve any pre-existing C-state entries with --accept=theirs-full
-#      (so the export writes onto a clean file, not one full of conflict markers)
-#   2. Run the two export scripts directly via python3 (override EXPORT_RUNNER to swap
-#      in your own invocation)
-#   3. svn add --force; svn commit
-#   4. On commit failure with E155015: re-resolve with --accept=mine-full, retry once
-#   5. On any unrecoverable failure: send_report via the Python shim, exit non-zero
-#   6. On success: touch .last_success sentinel for the freshness checker
+#   1. If /curation_status has no .svn/, run `svn checkout $SVN_REPO_URL` to
+#      create the working copy. Otherwise `svn update`; on E155036 (format too
+#      old), run `svn upgrade` and retry once.
+#   2. Auto-resolve any pre-existing C-state entries with --accept=theirs-full
+#      (so the export writes onto a clean file, not one full of conflict markers).
+#   3. Run the two export scripts directly via python3 (override EXPORT_RUNNER
+#      to swap in your own invocation).
+#   4. svn add --force; svn commit.
+#   5. On commit failure with E155015: re-resolve with --accept=mine-full, retry once.
+#   6. On any unrecoverable failure: send_report via the Python shim, exit non-zero.
+#   7. On success: touch .last_success sentinel for the freshness checker.
 #
 # Required env vars (typically set by the GoCD pipeline):
 #   CRONTAB_EMAIL, SENDER_EMAIL, SENDER_PASSWORD   - for alert dispatch
@@ -30,6 +39,10 @@
 #                                                    Other BLUE_* vars (USERNAME, HOST,
 #                                                    PORT, DATABASE) have prod defaults
 #                                                    baked into the Python scripts.
+#   SVN_REPO_URL                                   - the SVN URL to check out from on
+#                                                    first run (when .svn/ is missing).
+#                                                    Unused once the working copy
+#                                                    exists but cheap to keep set.
 #   SVN_PASSWORD                                   - consumed by svn via the cached
 #                                                    credentials bind-mounted from the
 #                                                    agent (not read by this script
@@ -96,16 +109,49 @@ run_export() {
 
 # ---- main ----
 
+mkdir -p "$CURATION_STATUS_DIR"
 if ! cd "$CURATION_STATUS_DIR"; then
     send_alert "FB ABC textmining: working copy unreachable" \
                "Cannot cd into CURATION_STATUS_DIR=$CURATION_STATUS_DIR on $(hostname)."
     exit 2
 fi
 
+if [[ ! -d "$CURATION_STATUS_DIR/.svn" ]]; then
+    if [[ -z "${SVN_REPO_URL:-}" ]]; then
+        send_alert "FB ABC textmining: SVN_REPO_URL not set on first run" \
+                   "Host: $(hostname)
+$CURATION_STATUS_DIR has no .svn/ directory and SVN_REPO_URL is unset, so the
+wrapper cannot bootstrap the working copy. Set SVN_REPO_URL in the GoCD task."
+        exit 2
+    fi
+    log "No .svn/ found in $CURATION_STATUS_DIR; running svn checkout $SVN_REPO_URL"
+    checkout_out=$(svn checkout "$SVN_REPO_URL" "$CURATION_STATUS_DIR" 2>&1)
+    checkout_rc=$?
+    log "$checkout_out"
+    if (( checkout_rc != 0 )); then
+        send_alert "FB ABC textmining: svn checkout failed" \
+                   "Host: $(hostname)
+Working copy: $CURATION_STATUS_DIR
+SVN_REPO_URL: $SVN_REPO_URL
+
+svn checkout output:
+$checkout_out"
+        exit "$checkout_rc"
+    fi
+fi
+
 log "Running svn update in $CURATION_STATUS_DIR"
 update_out=$(svn update 2>&1)
 update_rc=$?
 log "$update_out"
+if (( update_rc != 0 )) && grep -q "E155036" <<< "$update_out"; then
+    log "Working copy is in an older format; running svn upgrade and retrying"
+    upgrade_out=$(svn upgrade "$CURATION_STATUS_DIR" 2>&1)
+    log "$upgrade_out"
+    update_out=$(svn update 2>&1)
+    update_rc=$?
+    log "$update_out"
+fi
 if (( update_rc != 0 )); then
     send_alert "FB ABC textmining: svn update failed" \
                "Host: $(hostname)

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -4,17 +4,18 @@
 # This script is intended to run INSIDE the agr_document_classifier container.
 # The container owns the SVN working copy end-to-end: it checks it out on every
 # run (the WC is ephemeral; no host bind-mount), the export scripts write to it,
-# and the wrapper commits back. Freshness monitoring no longer depends on a
-# host-side file — it queries SVN directly (see bin/check_textmining_freshness.sh).
+# and the wrapper commits back. SVN auth comes from $SVN_USERNAME / $SVN_PASSWORD
+# (passed to every svn call via --username/--password --no-auth-cache), so no
+# ~/.subversion/ mount is needed. Freshness monitoring queries SVN directly
+# (see bin/check_textmining_freshness.sh).
 #
-# The GoCD task only needs to mount the agent's ~/.subversion/ for cached
-# credentials:
+# Example GoCD task:
 #
 #   docker run --rm \
 #     -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
+#     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
 #     -e CURATION_STATUS_DIR=/curation_status \
-#     -v "$HOME/.subversion:/root/.subversion" \
 #     agr_document_classifier \
 #     ./bin/run_export_and_commit.sh
 #
@@ -45,10 +46,9 @@
 #                                                    first run (when .svn/ is missing).
 #                                                    Unused once the working copy
 #                                                    exists but cheap to keep set.
-#   SVN_PASSWORD                                   - consumed by svn via the cached
-#                                                    credentials bind-mounted from the
-#                                                    agent (not read by this script
-#                                                    directly)
+#   SVN_USERNAME, SVN_PASSWORD                     - passed to every svn call as
+#                                                    --username/--password
+#                                                    --no-auth-cache
 #
 # Optional overrides:
 #   CURATION_STATUS_DIR  path of the SVN working copy inside the container. Defaults
@@ -64,6 +64,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Capture $PWD before we cd anywhere, so the default is the caller's CWD.
 CURATION_STATUS_DIR="${CURATION_STATUS_DIR:-$PWD/curation_status}"
+
+: "${SVN_USERNAME:?SVN_USERNAME must be set}"
+: "${SVN_PASSWORD:?SVN_PASSWORD must be set}"
+SVN_AUTH=(--non-interactive --no-auth-cache --username "$SVN_USERNAME" --password "$SVN_PASSWORD")
 
 log() { echo "[$(date -u +%FT%TZ)] $*"; }
 
@@ -127,7 +131,7 @@ wrapper cannot bootstrap the working copy. Set SVN_REPO_URL in the GoCD task."
         exit 2
     fi
     log "No .svn/ found in $CURATION_STATUS_DIR; running svn checkout $SVN_REPO_URL"
-    checkout_out=$(svn checkout "$SVN_REPO_URL" "$CURATION_STATUS_DIR" 2>&1)
+    checkout_out=$(svn "${SVN_AUTH[@]}" checkout "$SVN_REPO_URL" "$CURATION_STATUS_DIR" 2>&1)
     checkout_rc=$?
     log "$checkout_out"
     if (( checkout_rc != 0 )); then
@@ -143,14 +147,14 @@ $checkout_out"
 fi
 
 log "Running svn update in $CURATION_STATUS_DIR"
-update_out=$(svn update 2>&1)
+update_out=$(svn "${SVN_AUTH[@]}" update 2>&1)
 update_rc=$?
 log "$update_out"
 if (( update_rc != 0 )) && grep -q "E155036" <<< "$update_out"; then
     log "Working copy is in an older format; running svn upgrade and retrying"
     upgrade_out=$(svn upgrade "$CURATION_STATUS_DIR" 2>&1)
     log "$upgrade_out"
-    update_out=$(svn update 2>&1)
+    update_out=$(svn "${SVN_AUTH[@]}" update 2>&1)
     update_rc=$?
     log "$update_out"
 fi
@@ -187,7 +191,7 @@ svn add --force "$CURATION_STATUS_DIR" 2>&1 | while IFS= read -r line; do log " 
 
 commit_msg="automated textmining ABC update $(date -u +%FT%TZ)"
 log "Running svn commit: $commit_msg"
-commit_out=$(svn commit -m "$commit_msg" "$CURATION_STATUS_DIR" 2>&1)
+commit_out=$(svn "${SVN_AUTH[@]}" commit -m "$commit_msg" "$CURATION_STATUS_DIR" 2>&1)
 commit_rc=$?
 log "$commit_out"
 
@@ -199,7 +203,7 @@ fi
 if grep -q "E155015" <<< "$commit_out"; then
     log "Detected E155015 conflict on commit; auto-resolving with --accept=mine-full and retrying once"
     resolved_files=$(resolve_conflicts "mine-full")
-    retry_out=$(svn commit -m "$commit_msg (post-resolve retry)" "$CURATION_STATUS_DIR" 2>&1)
+    retry_out=$(svn "${SVN_AUTH[@]}" commit -m "$commit_msg (post-resolve retry)" "$CURATION_STATUS_DIR" 2>&1)
     retry_rc=$?
     log "$retry_out"
     if (( retry_rc == 0 )); then

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -2,23 +2,24 @@
 # Self-healing wrapper for the FlyBase ABC textmining export + SVN commit step.
 #
 # This script is intended to run INSIDE the agr_document_classifier container.
-# The container owns the SVN working copy end-to-end: it checks it out on first
-# run, updates it on subsequent runs, and commits back. GoCD must NOT also fetch
-# the SVN repo as a pipeline material into the same path, or the agent's svn
-# version may rewrite the working copy in an incompatible format.
+# The container owns the SVN working copy end-to-end: it checks it out on every
+# run (the WC is ephemeral; no host bind-mount), the export scripts write to it,
+# and the wrapper commits back. Freshness monitoring no longer depends on a
+# host-side file — it queries SVN directly (see bin/check_textmining_freshness.sh).
 #
-# The GoCD task should `docker run` the image with a persistent host directory
-# bind-mounted at /curation_status and the agent's ~/.subversion/ at
-# /root/.subversion/, e.g.:
+# The GoCD task only needs to mount the agent's ~/.subversion/ for cached
+# credentials:
 #
 #   docker run --rm \
 #     -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
 #     -e CURATION_STATUS_DIR=/curation_status \
-#     -v "$PWD/curation_status:/curation_status" \
 #     -v "$HOME/.subversion:/root/.subversion" \
 #     agr_document_classifier \
 #     ./bin/run_export_and_commit.sh
+#
+# CURATION_STATUS_DIR must be /curation_status: the export scripts hardcode
+# /curation_status/textmining_*.txt as their output path.
 #
 # Flow:
 #   1. If /curation_status has no .svn/, run `svn checkout $SVN_REPO_URL` to
@@ -31,7 +32,8 @@
 #   4. svn add --force; svn commit.
 #   5. On commit failure with E155015: re-resolve with --accept=mine-full, retry once.
 #   6. On any unrecoverable failure: send_report via the Python shim, exit non-zero.
-#   7. On success: touch .last_success sentinel for the freshness checker.
+#   7. On success: exit 0. Freshness is monitored separately via the wrapper's
+#      SVN commits (see bin/check_textmining_freshness.sh).
 #
 # Required env vars (typically set by the GoCD pipeline):
 #   CRONTAB_EMAIL, SENDER_EMAIL, SENDER_PASSWORD   - for alert dispatch
@@ -190,8 +192,7 @@ commit_rc=$?
 log "$commit_out"
 
 if (( commit_rc == 0 )); then
-    date -u +%FT%TZ > "$CURATION_STATUS_DIR/.last_success"
-    log "Commit succeeded; .last_success updated"
+    log "Commit succeeded"
     exit 0
 fi
 
@@ -202,7 +203,6 @@ if grep -q "E155015" <<< "$commit_out"; then
     retry_rc=$?
     log "$retry_out"
     if (( retry_rc == 0 )); then
-        date -u +%FT%TZ > "$CURATION_STATUS_DIR/.last_success"
         log "Retry commit succeeded after auto-resolve"
         # Still inform humans that self-heal kicked in, so a curator can sanity-check
         # the committed content. Non-fatal but worth eyes on.


### PR DESCRIPTION
## Summary
Follow-up to #118 so the container owns the SVN working copy end-to-end and never depends on the GoCD agent's svn version:

- If `/curation_status` has no `.svn/`, the wrapper now runs `svn checkout $SVN_REPO_URL` to create the working copy. New `SVN_REPO_URL` env var is required for this first-run path.
- If `svn update` fails with `E155036` (working copy format too old for the container's svn 1.14), the wrapper auto-runs `svn upgrade` and retries `svn update` once.

### Required GoCD config change
The pipeline must **stop fetching the same SVN repo as a material into `/curation_status`** — otherwise the agent's older svn will keep regressing the working copy to format 29 on every run.

### Updated `docker run` invocation
```
docker run --rm \
  -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
  -e SVN_REPO_URL=https://svn.flybase.org/documents/curation/curation_data/text_mining_flags/ \
  -e CURATION_STATUS_DIR=/curation_status \
  -v "$PWD/curation_status:/curation_status" \
  -v "$HOME/.subversion:/root/.subversion" \
  agr_document_classifier \
  ./bin/run_export_and_commit.sh
```

## Test plan
- [x] `bash -n bin/run_export_and_commit.sh` passes
- [x] Image rebuilt; checkout branch fires end-to-end on an empty bind-mount: reaches `svn.flybase.org`, fails only on auth (because `~/.subversion/` not mounted in the local dry-run); alert path dispatches through the shim as before
- [ ] First production run on the GoCD agent against the existing format-29 working copy — verifies the `svn upgrade` fallback path
- [ ] First production run with `~/.subversion/` mounted — verifies authenticated checkout/update/commit cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)