### PR TITLE
fix(deps): bump torch to 2.6.0 to patch critical torch.load RCE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,11 +68,11 @@ smart-open==7.0.4
 sniffio==1.3.1
 soupsieve==2.5
 starlette==0.46.0
-sympy==1.13.3
+sympy==1.13.1
 sqlalchemy==2.0.7
 threadpoolctl==3.5.0
 tokenizers
-torch==2.2.2
+torch==2.6.0
 tqdm==4.66.4
 transformers==4.48.0
 triton


### PR DESCRIPTION
GHSA-53q9-r3pm-6pq6 (`torch.load` with weights_only=True can lead to remote code execution). First patched version is 2.6.0.

torch 2.6.0 pins sympy==1.13.1 exactly, so sympy is downgraded from 1.13.3 to match the resolver.

The other dependabot critical (h11 < 0.16.0) is blocked at the package-manager level: grobid-client 0.8.8 (latest on PyPI) hard-pins httpx==0.23.0, which transitively forces h11<0.13. Bumping h11 would require either replacing or forking grobid-client and is left for a follow-up.