### PR TITLE
fix(deps): pin agr_literature_service to last known-good commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agr_literature_service @ git+https://github.com/alliance-genome/agr_literature_service
+agr_literature_service @ git+https://github.com/alliance-genome/agr_literature_service@cd202b2959ca4331eb92e0f00dcb0f194f1ee408
 annotated-types==0.7.0
 anyio==3.7.1
 attrs==21.4.0


### PR DESCRIPTION
## Summary

`requirements.txt` was pulling `agr_literature_service` from the unpinned `git+https://...` URL. Since the last successful CI on `main` (2026-05-14, commit `45d87c4`), `agr_literature_service` added top-level directories (`docker`, `alembic`, `debezium`, `non_pr_tests`, `reverse_proxy`, `file_uploader`) without configuring setuptools to limit package auto-discovery. As a result every new `pip install -r requirements.txt` now fails with:

```
error: Multiple top-level packages discovered in a flat-layout:
  ['docker', 'alembic', 'debezium', 'non_pr_tests', 'reverse_proxy',
   'file_uploader', 'agr_literature_service']
```

This blocks CI on every branch (including `main`).

This PR pins `agr_literature_service` to `cd202b2959ca4331eb92e0f00dcb0f194f1ee408` — the exact commit resolved by the last successful flake8 run on `main`. No other changes.

## Follow-up

Open a PR against `alliance-genome/agr_literature_service` to add an explicit `[tool.setuptools.packages.find]` (or `packages = ["agr_literature_service"]`) block to its `pyproject.toml`, so the dep can be safely unpinned here again.

## Test plan

- [ ] CI on this PR completes the `pip install -r requirements.txt` step successfully
- [ ] flake8 job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)