### PR TITLE
fix(SCRUM-6119): handle empty document batch in classification

### DIFF
--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -67,6 +67,12 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
 
     del embedding_model
     X = np.array(X)
+    if X.size == 0:
+        logger.warning(
+            "classify_documents called with zero loaded documents for input_docs_dir=%s; "
+            "skipping predict()", input_docs_dir,
+        )
+        return files_loaded, np.array([]), [], valid_embeddings
     classifications = classifier_model.predict(X)
     try:
         confidence_scores = [classes_proba[1] for classes_proba in classifier_model.predict_proba(X)]
@@ -144,6 +150,24 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
     prepare_classification_directory()
     download_md_files_for_references(list(reference_curie_job_map.keys()),
                                      "/data/agr_document_classifier/to_classify", mod_abbr)
+    expected_curies = set(reference_curie_job_map.keys())
+    downloaded_curies = {
+        os.path.splitext(f)[0].replace("_", ":")
+        for f in os.listdir("/data/agr_document_classifier/to_classify")
+        if f.endswith(".md") and ".supp_" not in f
+    }
+    missing_curies = expected_curies - downloaded_curies
+    if missing_curies:
+        logger.warning(
+            "No MD available in ABC for %d/%d references in this batch (mod=%s topic=%s); "
+            "marking those jobs failed",
+            len(missing_curies), len(expected_curies), mod_abbr, topic,
+        )
+        if not test_mode:
+            for curie in missing_curies:
+                job = reference_curie_job_map[curie]
+                set_job_started(job)
+                set_job_failure(job)
     files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
         embedding_model=embedding_model,
         classifier_model=classifier_model,

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -331,6 +331,12 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
 
     del embedding_model
     X = np.array(X)
+    if X.size == 0:
+        logger.warning(
+            "classify_documents called with zero loaded documents for input_docs_dir=%s; "
+            "skipping predict()", input_docs_dir,
+        )
+        return files_loaded, np.array([]), [], valid_embeddings
     classifications = classifier_model.predict(X)
 
     # For multi-class, use the probability corresponding to the predicted class

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -773,6 +773,14 @@ def download_md_files_for_references(reference_curies: List[str], output_dir: st
                 reference_curie, output_dir, mod_abbreviation,
             )
 
+    written = sum(
+        1 for f in os.listdir(output_dir)
+        if f.endswith(".md") and ".supp_" not in f
+    )
+    logger.info(
+        "Markdown download summary: requested=%d, written=%d, missing=%d",
+        len(reference_curies), written, len(reference_curies) - written,
+    )
     logger.info("Finished downloading Markdown files")
 
 


### PR DESCRIPTION
## Summary

Fixes [SCRUM-6119](https://agr-jira.atlassian.net/browse/SCRUM-6119) — classification has been crashing for ~2 days with `Expected 2D array, got 1D array instead: array=[]` on topic `ATP:0000207` / mod_id `1` (FB, "no genetic data").

**Root cause:** after SCRUM-5873 (commit `50c16db`, 2026-05-08) the non-BERT pipelines switched from local Grobid PDF→TEI→MD to pulling pre-converted MDs from ABC. If a reference has neither an MD nor a TEI registered in ABC, `download_md_files_for_references` silently produces nothing on disk; `get_documents` returns `[]`; `classify_documents` ends up with `X = np.array([])` (shape `(0,)`) and sklearn's `predict()` rejects the 1D array. The exception is caught at the `classify_mode` level, but the jobs in the failing batch never get transitioned in ABC, so they stay stuck in the queue.

## Changes

- `agr_document_classifier/agr_document_classifier_classify.py`
  - `classify_documents`: guard `predict()` on `X.size == 0` and return empty results — empty batch is now a no-op, not a crash.
  - `process_job_batch`: diff expected vs. downloaded curies after the MD download, log a WARNING with mod/topic context, and transition MD-less jobs through `set_job_started` → `set_job_failure` (skipped in `test_mode`) so they don't keep blocking the queue.
- `agr_document_classifier/agr_priority_classifier_balanced.py`: same `X.size == 0` guard in its parallel `classify_documents` — latent twin of the same crash.
- `utils/abc_utils.py` `download_md_files_for_references`: emit a `"Markdown download summary: requested=N, written=M, missing=K"` INFO line so the next batch-with-no-source-docs is visible at a glance without grepping per-curie WARNINGs.

## Test plan

- [ ] Run on stage with `--test_mode --mod_abbreviation FB --topic ATP:0000207 --reference_curie <known MD-less curie>`; expect no crash, the new "No MD available in ABC… marking those jobs failed" WARNING, no job transitions (test_mode)
- [ ] Run on stage without `--test_mode` against a small batch containing at least one MD-less reference; expect script to exit 0, the summary line to appear, and the MD-less reference's job to be transitioned to failed in ABC while MD-bearing references are processed normally
- [ ] Force an all-empty batch (every reference MD-less); expect the new `X.size == 0` WARNING and a clean "Finished processing batch of 0 jobs." line
- [ ] flake8: `make run-local-flake8` (already clean locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6119]: https://agr-jira.atlassian.net/browse/SCRUM-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ