### PR TITLE
fix(SCRUM-6122): classifier MD downloader accepts global converted_merged_main files

### DIFF
--- a/tests/utils/test_download_md_files.py
+++ b/tests/utils/test_download_md_files.py
@@ -248,3 +248,184 @@ def test_supplements_not_downloaded_by_default(
         # Only the main MD download was called; supplement was skipped.
         assert mock_download.call_count == 1
         assert mock_download.call_args[0][0]["referencefile_id"] == 1
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_global_main_md_is_used_when_no_mod_scoped_md(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """ABC stores converted_merged_main MDs globally (mod_id IS NULL,
+    surfaced as mod_abbreviation: None). The downloader must select that
+    row for any requested MOD instead of falling back to TEI conversion."""
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 500,
+            "referencefile_mods": [{"mod_abbreviation": None}],
+        },
+        # A MOD-scoped TEI exists too; it must NOT be used because MD wins.
+        {
+            "file_extension": "tei",
+            "file_class": "tei",
+            "referencefile_id": 600,
+            "referencefile_mods": [{"mod_abbreviation": "FB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# global md"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:101000000000077"], tmp, "FB",
+        )
+
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 500
+        out_path = os.path.join(tmp, "AGRKB_101000000000077.md")
+        assert os.path.exists(out_path)
+        with open(out_path, "rb") as fh:
+            assert fh.read() == b"# global md"
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_main_md_with_empty_referencefile_mods_is_used(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """Defensive: a converted_merged_main row whose referencefile_mods is
+    an empty list is also a global file and must be selectable."""
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 700,
+            "referencefile_mods": [],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# empty-mods md"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(["AGRKB:1"], tmp, "FB")
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 700
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_main_md_scoped_to_other_mod_only_is_skipped(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """A converted_merged_main row scoped exclusively to a different MOD
+    must NOT be selected, even when the requested MOD has no MD. The
+    downloader should fall through to the TEI fallback for the requested
+    MOD."""
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 800,
+            "referencefile_mods": [{"mod_abbreviation": "MGI"}],
+        },
+        {
+            "file_extension": "tei",
+            "file_class": "tei",
+            "referencefile_id": 801,
+            "referencefile_mods": [{"mod_abbreviation": "FB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    tei_bytes = b"<TEI/>"
+    mock_download.return_value = tei_bytes
+
+    with patch("agr_abc_document_parsers.convert_xml_to_markdown",
+               return_value="# from tei") as mock_convert:
+        with tempfile.TemporaryDirectory() as tmp:
+            abc_utils.download_md_files_for_references(
+                ["AGRKB:1"], tmp, "FB",
+            )
+            # The MGI-only MD must not be downloaded; the FB TEI must be.
+            assert mock_download.call_count == 1
+            assert mock_download.call_args[0][0]["referencefile_id"] == 801
+            mock_convert.assert_called_once_with(tei_bytes, "tei")
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_global_supplement_md_is_downloaded(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """converted_merged_supplement rows are stored under the same global
+    convention as main MDs; they must be downloaded when in scope (mod-
+    scoped or global) for the requested MOD."""
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 900,
+            "referencefile_mods": [{"mod_abbreviation": None}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 901,
+            "referencefile_mods": [{"mod_abbreviation": None}],
+        },
+        # Wrong-MOD supplement → must be skipped
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_supplement",
+            "referencefile_id": 902,
+            "referencefile_mods": [{"mod_abbreviation": "MGI"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+
+    def _fake_dl(ref):
+        return (f"# id-{ref['referencefile_id']}").encode("utf-8")
+    mock_download.side_effect = _fake_dl
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(
+            ["AGRKB:1"], tmp, "FB", include_supplements=True,
+        )
+        files = sorted(os.listdir(tmp))
+        assert files == ["AGRKB_1.md", "AGRKB_1.supp_1.md"]
+        with open(os.path.join(tmp, "AGRKB_1.supp_1.md"), "rb") as fh:
+            assert fh.read() == b"# id-901"
+
+
+def test_reffile_matches_mod_helper():
+    """Direct coverage for the in-scope predicate."""
+    matches = abc_utils._reffile_matches_mod
+
+    # Mod-scoped to requested MOD
+    assert matches({"referencefile_mods": [{"mod_abbreviation": "FB"}]}, "FB")
+    # Global (mod_abbreviation: None) → in scope for any MOD
+    assert matches({"referencefile_mods": [{"mod_abbreviation": None}]}, "FB")
+    assert matches({"referencefile_mods": [{"mod_abbreviation": None}]}, "WB")
+    # Empty referencefile_mods list → treated as global
+    assert matches({"referencefile_mods": []}, "FB")
+    # Missing referencefile_mods key → treated as global
+    assert matches({}, "FB")
+    # Mixed: one entry global, one entry different MOD → still in scope
+    assert matches({"referencefile_mods": [{"mod_abbreviation": "MGI"},
+                                           {"mod_abbreviation": None}]}, "FB")
+    # Mixed: requested MOD present alongside another → in scope
+    assert matches({"referencefile_mods": [{"mod_abbreviation": "MGI"},
+                                           {"mod_abbreviation": "FB"}]}, "FB")
+    # Scoped exclusively to a different MOD → out of scope
+    assert not matches({"referencefile_mods": [{"mod_abbreviation": "MGI"}]}, "FB")
+    # Multiple different MODs, none matching, none global → out of scope
+    assert not matches({"referencefile_mods": [{"mod_abbreviation": "MGI"},
+                                               {"mod_abbreviation": "WB"}]}, "FB")

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -801,9 +801,28 @@ def _show_all_for_reference(reference_curie: str) -> Optional[list]:
         return None
 
 
+def _reffile_matches_mod(rf: dict, mod_abbreviation: str) -> bool:
+    """Return True if ``rf`` is in scope for ``mod_abbreviation``.
+
+    A referencefile row is in scope when it is either mod-scoped to
+    ``mod_abbreviation`` or stored as a global (mod-less) file. ABC stores
+    ``converted_merged_main`` MDs globally (``mod_id IS NULL``, surfaced by the
+    API as ``mod_abbreviation = None``); TEIs are mod-scoped. Both must be
+    selectable here.
+    """
+    mods = rf.get("referencefile_mods") or []
+    if not mods:
+        return True
+    return any(
+        m.get("mod_abbreviation") in (mod_abbreviation, None)
+        for m in mods
+    )
+
+
 def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviation: str) -> bool:
-    """Try to write a ``<curie>.md`` file using the main MD row first, then a
-    TEI-row fallback converted in-process. Returns True iff a file was written.
+    """Try to write a ``<curie>.md`` file, preferring an existing main MD row
+    and falling back to in-process TEI->MD conversion. Returns True iff a file
+    was written.
     """
     from agr_abc_document_parsers import convert_xml_to_markdown
 
@@ -818,8 +837,7 @@ def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviatio
         (rf for rf in resp_obj
          if rf.get("file_extension") == "md"
          and rf.get("file_class") == "converted_merged_main"
-         and any(m.get("mod_abbreviation") == mod_abbreviation
-                 for m in rf.get("referencefile_mods", []))),
+         and _reffile_matches_mod(rf, mod_abbreviation)),
         None,
     )
     if md_ref_file is not None:
@@ -834,8 +852,7 @@ def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviatio
         (rf for rf in resp_obj
          if rf.get("file_extension") == "tei"
          and rf.get("file_class") == "tei"
-         and any(m.get("mod_abbreviation") == mod_abbreviation
-                 for m in rf.get("referencefile_mods", []))),
+         and _reffile_matches_mod(rf, mod_abbreviation)),
         None,
     )
     if tei_ref_file is None:
@@ -856,8 +873,9 @@ def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviatio
 
 
 def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abbreviation: str) -> None:
-    """Download every ``converted_merged_supplement`` MD row for ``mod_abbreviation``
-    and write them as ``<curie>.supp_<N>.md`` (numbered in API order).
+    """Download every ``converted_merged_supplement`` MD row in scope for
+    ``mod_abbreviation`` (mod-scoped or global) and write them as
+    ``<curie>.supp_<N>.md`` (numbered in API order).
     """
     resp_obj = _show_all_for_reference(reference_curie)
     if resp_obj is None:
@@ -868,8 +886,7 @@ def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abb
         rf for rf in resp_obj
         if rf.get("file_extension") == "md"
         and rf.get("file_class") == "converted_merged_supplement"
-        and any(m.get("mod_abbreviation") == mod_abbreviation
-                for m in rf.get("referencefile_mods", []))
+        and _reffile_matches_mod(rf, mod_abbreviation)
     ]
     for idx, supp in enumerate(supp_ref_files, start=1):
         supp_bytes = get_file_from_abc_reffile_obj(supp)


### PR DESCRIPTION
## Summary

After SCRUM-5873 the classifier expects pre-converted MDs from ABC's `converted_merged_main` rows. In ABC's current storage convention those MDs are global (`referencefile_mod.mod_id IS NULL`); the literature-service API surfaces them as `referencefile_mods: [{"mod_abbreviation": null, ...}]`. The downloader required `any(m["mod_abbreviation"] == mod_abbr)` — which is `None == "FB"` — so it matched **zero** global MD rows (286,936 / 286,983 such rows in literature-dev are global). Every classification run was silently falling back to in-process TEI→MD conversion; batches whose TEIs all failed conversion produced the empty-`X` crash that SCRUM-6119 masked.

- New `_reffile_matches_mod` helper accepts a row when it's mod-scoped to the requested MOD **or** stored globally (empty `referencefile_mods`, or any entry with `mod_abbreviation is None`).
- `_try_download_main_md` uses the helper for both MD-main and TEI selectors; MD-then-TEI preference unchanged.
- `_download_main_md_supplements` uses the helper — `converted_merged_supplement` uses the same global-storage convention.
- TEI selector stays effectively strict because the DB has 0 unscoped TEIs across all MODs.

## Test plan

- [x] `python3 -m pytest tests/utils/test_download_md_files.py` — 11/11 pass (6 existing + 5 new)
- [x] Existing negative case `test_downloads_only_main_md_for_matching_mod` still rejects MGI MD when querying WB
- [x] New `test_main_md_scoped_to_other_mod_only_is_skipped` pins down the negative path with explicit TEI fallback
- [x] flake8 clean (max-line-length=120) on changed files
- [x] All 6 downstream callers of `download_md_files_for_references` are pure consumers of the resulting `<curie>.md` — no caller depends on which scoping branch produced the file
- [ ] After deploy, confirm `"Markdown download summary: requested=N, written=M, missing=K"` log line shows `missing` near 0 for FB

Jira: [SCRUM-6122](https://agr-jira.atlassian.net/browse/SCRUM-6122)
Related: SCRUM-5873 (introduced the storage mismatch), SCRUM-6119 (crash-masking fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6122]: https://agr-jira.atlassian.net/browse/SCRUM-6122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ