### PR TITLE
fix(SCRUM-6123): fetch PMC XML via eutils efetch, not retired OA tar.gz

### DIFF
--- a/bert_entity_extraction/annotation_helper.py
+++ b/bert_entity_extraction/annotation_helper.py
@@ -23,9 +23,7 @@ import argparse
 import configparser
 import sys
 import logging
-import subprocess
 import requests
-import xmltodict
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
@@ -107,65 +105,37 @@ def create_postgres_session(db):
     return session
 
 
-@retry(requests.exceptions.RequestException, delay=30, backoff=2, tries=10)
-def getFtpPath(pmcid: str):
-    """Returns the ftp path to a paper given its pmcid
+@retry(requests.exceptions.RequestException, delay=30, backoff=2, tries=5)
+def fetch_pmc_xml(pmcid: str) -> str:
+    """Fetch the PMC article XML via NCBI eutils efetch and write it to
+    ``{PATHS.xml}/{pmcid}.nxml``. Returns the path to the written file.
 
-    Parameters:
-        pmcid, str
-            The pmcid of the paper
+    Raises ``requests.exceptions.RequestException`` after retries on persistent
+    failure; the caller should catch and mark the job failed.
+
+    Replaces the retired OA bulk-tar pipeline (see SCRUM-6123). NCBI removed
+    ``/pub/pmc/oa_package/`` from ftp.ncbi.nlm.nih.gov; efetch returns the
+    article XML directly in a single GET.
     """
-    pmc_api_url = "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi?id=" + pmcid
-    try:
-        response = requests.get(pmc_api_url)
-        response.raise_for_status()  # Check for any request errors
-        dict_data = xmltodict.parse(response.content)
-        ftplink = ""
-        if "error" in dict_data['OA']:
-            error_code = dict_data['OA']['error']['@code']
-            logging.warning(f"ERROR: Could not find FTP path for {pmcid}: {error_code}")
-        else:
-            link = dict_data['OA']['records']['record']['link']
-            if isinstance(link, list):
-                ftplink = link[0]['@href']
-            else:
-                ftplink = link['@href']
-            assert (".tar.gz" in ftplink)
-        time.sleep(config_parser.getint('PARAMETERS', 'sleep_time_between_requests'))
-        return ftplink
-    except (requests.exceptions.RequestException, KeyError, AssertionError) as e:
-        logging.warning(f"Failed to get FTP path for {pmcid}: {str(e)}")
-    return None
-
-
-@retry(subprocess.CalledProcessError, delay=30, backoff=2, tries=10)
-def download(ftp: str):
-    """Downloads a paper given its ftp path. Raises CalledProcessError on failure
-    so callers can react; the @retry decorator handles transient errors.
-
-    Parameters:
-        ftp, str
-            The ftp path to the paper
-    """
-    wget = f"wget -nc --timeout=10 --no-verbose -P {config_parser.get('PATHS', 'corpus')} {ftp}"
-    subprocess.run(wget, shell=True, check=True)
-
-
-def getXmlFromTar(pmcid: str):
-    """Extracts the xml file from the tar.gz file. Raises CalledProcessError on failure.
-
-    Parameters:
-        pmcid, str
-            The pmcid of the paper
-    """
-    f = f"{config_parser.get('PATHS', 'corpus')}/{pmcid}.tar.gz"
-    untar = f"tar -xf {f} -C {config_parser.get('PATHS', 'corpus')}"
-    subprocess.run(untar, shell=True, check=True)
-    # make xml directory if it doesn't exist
-    if not os.path.exists(config_parser.get('PATHS', 'xml')):
-        os.makedirs(config_parser.get('PATHS', 'xml'))
-    copy_xml = f"cp {config_parser.get('PATHS', 'corpus')}/{pmcid}/*.nxml {config_parser.get('PATHS', 'xml')}/{pmcid}.nxml"
-    subprocess.run(copy_xml, shell=True, check=True)
+    xml_dir = config_parser.get('PATHS', 'xml')
+    os.makedirs(xml_dir, exist_ok=True)
+    out_path = os.path.join(xml_dir, f"{pmcid}.nxml")
+    pmc_id_num = pmcid.removeprefix("PMC")
+    params = {"db": "pmc", "id": pmc_id_num}
+    api_key = os.environ.get("NCBI_API_KEY")
+    if api_key:
+        params["api_key"] = api_key
+    email = os.environ.get("NCBI_EMAIL")
+    if email:
+        params["email"] = email
+    url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    response = requests.get(url, params=params, timeout=60)
+    response.raise_for_status()
+    with open(out_path, "wb") as f:
+        f.write(response.content)
+    # Stay polite to eutils between calls; same param the OA-API path used.
+    time.sleep(config_parser.getint('PARAMETERS', 'sleep_time_between_requests'))
+    return out_path
 
 
 def get_ateam_dicts() -> (dict[str, str], dict[str, str]):
@@ -232,20 +202,7 @@ def get_data_from_alliance_db():
 
 
 def removeFiles(pmcid: str):
-    """Removes paper files that were downloaded
-
-    Parameters:
-        pmcid, str
-            The pmcid of the paper
-    """
-    f = f"{config_parser.get('PATHS', 'corpus')}/{pmcid}.tar.gz"
-    try:
-        os.remove(f)
-    except FileNotFoundError:
-        pass
-    f = f"{config_parser.get('PATHS', 'corpus')}/{pmcid}"
-    # remove extracted directory
-    subprocess.run(f"rm -r {f}", shell=True, check=False)
+    """Removes the downloaded XML for a paper."""
     f = f"{config_parser.get('PATHS', 'xml')}/{pmcid}.nxml"
     try:
         os.remove(f)
@@ -274,9 +231,9 @@ def main():  # noqa C901
         os.environ['ABC_API_SERVER'] = "https://stage-literature-rest.alliancegenome.org"
 
     counters = {
-        "jobs_loaded": 0, "no_pmcid": 0, "ftp_missing": 0,
-        "download_failed": 0, "extract_failed": 0, "no_candidates": 0,
-        "no_nxml": 0, "matches_high": 0, "matches_medium": 0, "matches_low": 0,
+        "jobs_loaded": 0, "no_pmcid": 0, "xml_fetch_failed": 0,
+        "no_candidates": 0, "no_nxml": 0,
+        "matches_high": 0, "matches_medium": 0, "matches_low": 0,
         "tet_upload_failed": 0, "job_status_set_failed": 0,
     }
 
@@ -325,30 +282,11 @@ def main():  # noqa C901
         pmcid = ref_to_pmc[ref_id]
         logger.debug(f"pmcid -> {pmcid} job_id-> {job['reference_workflow_tag_id']} ref_id -> {ref_id}")
 
-        ftp = getFtpPath(pmcid)
-        if ftp is None:
-            logger.warning(f"Error processing {pmcid}: No ftp file available")
-            counters["ftp_missing"] += 1
-            if not set_job_failure(job):
-                logger.error(f"Problem setting to job failure {job}!!!")
-                counters["job_status_set_failed"] += 1
-            continue
-
         try:
-            download(ftp)
-        except subprocess.CalledProcessError as e:
-            logger.warning(f"download failed for pmcid={pmcid} after retries: {e}")
-            counters["download_failed"] += 1
-            if not set_job_failure(job):
-                logger.error(f"Problem setting to job failure {job}!!!")
-                counters["job_status_set_failed"] += 1
-            continue
-
-        try:
-            getXmlFromTar(pmcid)
-        except subprocess.CalledProcessError as e:
-            logger.warning(f"extract failed for pmcid={pmcid}: {e}")
-            counters["extract_failed"] += 1
+            xml_path = fetch_pmc_xml(pmcid)
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"efetch failed for pmcid={pmcid} after retries: {e}")
+            counters["xml_fetch_failed"] += 1
             if not set_job_failure(job):
                 logger.error(f"Problem setting to job failure {job}!!!")
                 counters["job_status_set_failed"] += 1
@@ -356,7 +294,7 @@ def main():  # noqa C901
 
         try:
             results, status = deep_learning.get_genes_with_dl(
-                os.path.join(config_parser.get('PATHS', 'xml'), pmcid + ".nxml"),
+                xml_path,
                 gene_dict, fbid_to_symbol, EXCEPTIONS_PATH)
             if results:
                 okay = True


### PR DESCRIPTION
## Summary

Fixes [SCRUM-6123](https://agr-jira.atlassian.net/browse/SCRUM-6123). NCBI has retired the bulk PMC OA tar.gz distribution at `ftp.ncbi.nlm.nih.gov/pub/pmc/oa_package/` — not just one file, the entire `/pub/pmc/oa_package/` tree returns 404 over both FTP (wget exit 8) and HTTPS. The OA lookup API at `oa.fcgi` still hands out the old `ftp://...tar.gz` URLs but they no longer resolve. This blocks every paper the BERT entity-extraction pipeline tries to process, which is the underlying cause of the `good:0, bad:55` symptom seen during SCRUM-6114 investigation.

eutils `efetch` returns the article XML directly in a single GET — exactly the content the pipeline was extracting from inside the tar. So we drop the OA-API → wget → tar → copy chain entirely and call efetch instead.

## Verification (2026-05-22)

- `oa.fcgi?id=PMC4291145` still returns `link href="ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_package/08/74/PMC4291145.tar.gz"` with `license="CC BY" retracted="no"`
- That URL: HTTP 404 over HTTPS, exit code 8 over FTP
- `https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_package/` (tree root): HTTP 404 — confirms the whole bulk service is gone
- `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pmc&id=4291145`: returns the full PMC article XML

## Changes

- **Replace** `getFtpPath` + `download` + `getXmlFromTar` with a single `fetch_pmc_xml(pmcid)` that calls eutils efetch and writes the response straight to `{PATHS.xml}/{pmcid}.nxml`. Returns the path.
- **Retry**: still `@retry(requests.exceptions.RequestException, ...)` but bounded to **5 tries** rather than 10 — permanent 404s should fail fast.
- **API key support**: picks up `NCBI_API_KEY` and `NCBI_EMAIL` from env if set (raises NCBI's anonymous 3 req/s limit to 10 req/s and reduces the chance of throttling). Falls back to anonymous when unset.
- **`main()` loop**: three try-blocks (FTP-path / download / extract) collapse into one `fetch_pmc_xml` try-block. Counters `ftp_missing` / `download_failed` / `extract_failed` collapse into a single `xml_fetch_failed`.
- **`removeFiles`** simplifies — only the nxml file needs deletion; no more tarball or extracted dir.
- **Drop** now-unused imports `subprocess`, `xmltodict`.

Net: 37 insertions, 99 deletions.

## Test plan

- [ ] Rebuild the `agr_document_classifier` image, re-run the production invocation
- [ ] Confirm `[PROBE]` lines fire (SCRUM-6114 visibility intact) and `RUN SUMMARY` shows non-zero `matches_*` for a batch that previously read `0` matches
- [ ] Spot-check one known-good PMCID end-to-end: efetch returns 200, `.nxml` lands at `xml/PMC4291145.nxml`, BERT scores at least one candidate
- [ ] Force the failure path: pass a non-existent PMCID; expect 5 retries logged, then `xml_fetch_failed += 1` and the job transitioned to failed in ABC
- [ ] (Optional but recommended) Set `NCBI_API_KEY` and `NCBI_EMAIL` env vars in the production runtime config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6123]: https://agr-jira.atlassian.net/browse/SCRUM-6123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ