### PR TITLE
fix(SCRUM-6163): harden ABC API calls for strict-REST error responses

### DIFF
--- a/tests/utils/test_send_tag_error_handling.py
+++ b/tests/utils/test_send_tag_error_handling.py
@@ -1,0 +1,197 @@
+"""Regression tests for the SCRUM-5716 strict-REST API migration (SCRUM-6163).
+
+The send_*_to_abc / create_workflow_tag helpers POST via urllib.request.urlopen,
+which raises urllib.error.HTTPError / URLError — not
+requests.exceptions.RequestException. A single reference's failure must never
+crash the surrounding job batch, and the server's idempotent "already exists"
+responses must be treated as benign no-ops on re-runs.
+
+Note: send_classification_tag_to_abc / send_entity_tag_to_abc are covered
+separately in test_abc_utils_note.py (the SCRUM-5716 / PR #127 work).
+"""
+
+import io
+import json
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+from utils import abc_utils
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen() context manager response."""
+
+    def __init__(self, code: int = 201):
+        self._code = code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def getcode(self) -> int:
+        return self._code
+
+
+def _http_error(code: int, body: str = "") -> HTTPError:
+    return HTTPError(
+        url="http://abc/test",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=io.BytesIO(body.encode("utf-8")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# send_manual_indexing_to_abc
+# ---------------------------------------------------------------------------
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_201_returns_true(mock_urlopen, _tok):
+    mock_urlopen.return_value = _FakeResponse(201)
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is True
+    assert mock_urlopen.call_count == 1
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_422_already_exists_no_crash_returns_false(
+    mock_urlopen, _tok, mock_sleep,
+):
+    """A duplicate-row 422 must not crash the batch, but it must NOT be treated
+    as success either: returning True would mask other validation failures and
+    incorrectly advance failed jobs to done (SCRUM-6062). So: no crash, no
+    retry, return False."""
+    mock_urlopen.side_effect = _http_error(
+        422,
+        json.dumps({
+            "detail": "ManualIndexingTag already exists for "
+                      "reference_curie=AGRKB:1, mod_abbreviation=FB, "
+                      "curation_tag=ATP:0000207"
+        }),
+    )
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is False
+    # No retry on a deterministic 4xx.
+    assert mock_urlopen.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_422_other_returns_false(mock_urlopen, _tok, mock_sleep):
+    mock_urlopen.side_effect = _http_error(
+        422, json.dumps({"detail": "Reference with curie AGRKB:1 does not exist"}),
+    )
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is False
+    # Non-duplicate client error: no retry.
+    assert mock_urlopen.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_4xx_does_not_raise(mock_urlopen, _tok, mock_sleep):
+    """The original bug: a 4xx HTTPError used to propagate uncaught and crash
+    the whole batch."""
+    mock_urlopen.side_effect = _http_error(400, "bad payload")
+    # Must not raise.
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is False
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_5xx_retries_then_returns_false(
+    mock_urlopen, _tok, mock_sleep,
+):
+    mock_urlopen.side_effect = _http_error(503, "upstream unavailable")
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is False
+    assert mock_urlopen.call_count == 3
+    # backoff sleeps between attempts 1 and 2, and 2 and 3.
+    assert mock_sleep.call_count == 2
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_url_error_retries_then_returns_false(
+    mock_urlopen, _tok, mock_sleep,
+):
+    mock_urlopen.side_effect = URLError("connection refused")
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is False
+    assert mock_urlopen.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@patch("utils.abc_utils.time.sleep")
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_manual_indexing_5xx_then_201_succeeds(mock_urlopen, _tok, mock_sleep):
+    mock_urlopen.side_effect = [
+        _http_error(503, "upstream unavailable"),
+        _FakeResponse(201),
+    ]
+    assert abc_utils.send_manual_indexing_to_abc(
+        "AGRKB:1", "FB", "ATP:0000207", 0.9
+    ) is True
+    assert mock_urlopen.call_count == 2
+    assert mock_sleep.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_pmids_from_reference_curies
+# ---------------------------------------------------------------------------
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+def test_get_pmids_one_bad_curie_does_not_crash_loop(mock_urlopen, _tok):
+    """A 404 (or any HTTPError) for a single reference must not abort the whole
+    loop; that curie maps to None and the rest are still processed."""
+    good_body = json.dumps({
+        "cross_references": [{"curie": "PMID:12345"}]
+    }).encode("utf-8")
+
+    class _ReadResp:
+        def __init__(self, body):
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            return self._body
+
+    mock_urlopen.side_effect = [
+        _http_error(404, json.dumps({"detail": "not found"})),
+        _ReadResp(good_body),
+    ]
+    result = abc_utils.get_pmids_from_reference_curies(["AGRKB:bad", "AGRKB:good"])
+    assert result == {"AGRKB:bad": None, "AGRKB:good": "PMID:12345"}

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -7,7 +7,7 @@ import urllib.request
 from argparse import Namespace
 from collections import defaultdict
 from typing import List, Tuple, Dict, Union, Optional
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import numpy as np
 import psycopg2
@@ -181,6 +181,14 @@ def get_tet_source_id(mod_abbreviation: str, source_method: str, source_descript
             raise
 
 
+def _read_http_error_body(exc: HTTPError) -> str:
+    """Return the response body of an HTTPError as text, swallowing read errors."""
+    try:
+        return exc.read().decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
 def send_manual_indexing_to_abc(reference_curie: str, mod_abbr: str, topic: str, confidence_score: float):
     url = f'{blue_api_base_url}/manual_indexing_tag/'
     token = get_authentication_token()
@@ -199,16 +207,40 @@ def send_manual_indexing_to_abc(reference_curie: str, mod_abbr: str, topic: str,
             create_request.add_header("Content-type", "application/json")
             create_request.add_header("Accept", "application/json")
             with urllib.request.urlopen(create_request) as create_response:
-                if create_response.getcode() == 201:
+                # 200/201 both mean the tag is present as intended.
+                if create_response.getcode() in (200, 201):
                     logger.debug("Manual Indexing Tag created")
                 else:
                     logger.error(f"Failed to create Manual Indexing Tag (attempt {attempts}): {str(mit_data)}")
             return True
-        except requests.exceptions.RequestException as exc:
+        except HTTPError as exc:
+            # urllib raises HTTPError (a URLError subclass, NOT a requests exception) on any
+            # 4xx/5xx, so catch it here to stop a single reference from crashing the batch.
+            if 400 <= exc.code < 500:
+                # Client errors (incl. the 422 "already exists" duplicate from
+                # POST /manual_indexing_tag/) are deterministic, so do not retry. Per
+                # SCRUM-6062 we deliberately do NOT treat "already exists" as success:
+                # returning True would mask other validation failures and incorrectly
+                # advance failed jobs to done. Skip the reference and return False.
+                if exc.code == 422 and "already exists" in _read_http_error_body(exc):
+                    logger.warning(f"{reference_curie}: manual indexing tag already exists; "
+                                   f"not retrying and not marking the job done")
+                else:
+                    logger.error(f"{reference_curie}: HTTP {exc.code} creating manual indexing tag; "
+                                 f"not retrying")
+                return False
+            # Server errors (5xx) are transient: retry, then give up without crashing.
             if attempts >= 3:
-                logger.error(f"Error trying to send manual indexing tag to ABC {attempts} times.")
-                logger.error(f"curie: {reference_curie}, mod_abbr: {mod_abbr}, topic: {topic}, confidence_score: {confidence_score}")
-                raise RuntimeError("Error Sending manual indexing tag to abc FAILED") from exc
+                logger.error(f"{reference_curie}: HTTP {exc.code} creating manual indexing tag after "
+                             f"{attempts} attempts; giving up")
+                return False
+            time.sleep(attempts)
+        except (URLError, requests.exceptions.RequestException) as exc:
+            if attempts >= 3:
+                logger.error(f"Error trying to send manual indexing tag to ABC {attempts} times: {exc}")
+                logger.error(f"curie: {reference_curie}, mod_abbr: {mod_abbr}, topic: {topic}, "
+                             f"confidence_score: {confidence_score}")
+                return False
             time.sleep(attempts)
     return False
 
@@ -521,14 +553,19 @@ def get_pmids_from_reference_curies(curies: List[str]):
         request = urllib.request.Request(url=ref_data_api, headers=headers)
         request.add_header("Content-type", "application/json")
         request.add_header("Accept", "application/json")
-        with urllib.request.urlopen(request) as response:
-            resp = response.read().decode("utf8")
-            resp_obj = json.loads(resp)
-            try:
-                curie_pmid[curie] = [xref["curie"] for xref in resp_obj["cross_references"]
-                                     if xref["curie"].startswith("PMID")][0]
-            except IndexError:
-                curie_pmid[curie] = None
+        try:
+            with urllib.request.urlopen(request) as response:
+                resp = response.read().decode("utf8")
+                resp_obj = json.loads(resp)
+            curie_pmid[curie] = [xref["curie"] for xref in resp_obj.get("cross_references", [])
+                                 if xref["curie"].startswith("PMID")][0]
+        except IndexError:
+            # No PMID cross-reference for this reference.
+            curie_pmid[curie] = None
+        except (HTTPError, URLError) as exc:
+            # A failed lookup for one reference must not abort the whole batch.
+            logger.error(f"Error fetching reference {curie} for PMID lookup: {exc}")
+            curie_pmid[curie] = None
     return curie_pmid
 
 


### PR DESCRIPTION
## SCRUM-6163 — align automated-extraction ABC API calls with the SCRUM-5716 strict-REST contract

`urllib.request.urlopen` raises `urllib.error.HTTPError` (a `URLError` subclass, **not** a `requests.exceptions.RequestException`), so 4xx/5xx responses from the new strict-REST API were propagating uncaught and crashing whole job batches.

### Changes (`utils/abc_utils.py`)
- **`send_manual_indexing_to_abc`** — catch `HTTPError`/`URLError` so a single reference can't abort the batch. On 4xx (incl. the **422 "already exists"** duplicate) do not retry; per the SCRUM-6062 decision we deliberately do **not** treat "already exists" as success (returning `True` would mask other validation failures and incorrectly advance failed jobs to done) → return `False`. 5xx / network → retry then return `False` (no longer raises).
- **`get_pmids_from_reference_curies`** — wrap each per-curie lookup so one bad/missing reference maps to `None` instead of crashing the loop.

### Already done elsewhere (verified, no change needed)
- TET helpers — `send_classification_tag_to_abc` (200/201 + 409), `send_entity_tag_to_abc`, `get_tet_source_id` — were migrated in **PR #127**.
- `create_workflow_tag` already catches `HTTPError`; its 422-on-duplicate is pre-existing (not a 5716 change) — left as-is.
- dataset / `data_entry` use `requests` + `raise_for_status` and their POST contracts are unchanged (`DatasetSchemaShow` still exposes `dataset_id`/`version`; only PATCH `/datasets/` migrated, which this repo doesn't call).

### Tests
- New `tests/utils/test_send_tag_error_handling.py` covering the manual-indexing 200/201/422/4xx/5xx/URLError paths and the `get_pmids` per-curie resilience. All pass; `flake8` clean.

Supersedes **SCRUM-6165** (closed as duplicate). Addresses the residual code-fragility from **SCRUM-6062** (which was resolved as a data fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)