### PR TITLE
feat(training): SCRUM-6132 — optional stateless classifier features (BoW, max-pooling, LSH)

### DIFF
--- a/agr_dataset_manager/dataset_downloader.py
+++ b/agr_dataset_manager/dataset_downloader.py
@@ -12,26 +12,29 @@ blue_api_base_url = os.environ.get('API_SERVER', "literature-rest.alliancegenome
 
 
 def download_md_files_from_abc_or_convert_pdf(reference_ids_positive, reference_ids_negative, output_dir,
-                                              mod_abbreviation):
+                                              mod_abbreviation, request_conversion: bool = False):
     """Populate ``output_dir/{positive,negative}`` with one ``.md`` file per reference.
 
     Source priority (handled inside :func:`download_md_files_for_references`):
 
     1. Main MD file from ABC (``converted_merged_main`` / ``.md``).
     2. TEI file from ABC, converted on the fly to Markdown via the shared library.
-    3. Server-side on-demand conversion via
-       ``GET /reference/referencefile/conversion_request/{curie}`` (PDF or
-       nXML in ABC → MD), enabled by ``request_conversion=True``. This
-       replaces the older local Grobid PDF→TEI→MD path.
+    3. (Only when ``request_conversion=True``) server-side on-demand conversion via
+       ``GET /reference/referencefile/conversion_request/{curie}``.
+
+    ``request_conversion`` defaults to ``False`` for training-set construction:
+    a reference with no MD/TEI means its upload/conversion is incomplete, and we
+    deliberately exclude it from the training set rather than trigger an
+    on-demand conversion.
     """
     logger.info(f"Positive MD files download started. Number of files to download: {len(reference_ids_positive)}")
     output_dir_positive = os.path.join(output_dir, "positive")
     download_md_files_for_references(reference_ids_positive, output_dir_positive,
-                                     mod_abbreviation, request_conversion=True)
+                                     mod_abbreviation, request_conversion=request_conversion)
     logger.info(f"Negative MD files download started. Number of files to download: {len(reference_ids_negative)}")
     output_dir_negative = os.path.join(output_dir, "negative")
     download_md_files_for_references(reference_ids_negative, output_dir_negative,
-                                     mod_abbreviation, request_conversion=True)
+                                     mod_abbreviation, request_conversion=request_conversion)
 
     downloaded_reference_ids_positive = [
         os.path.splitext(name)[0].replace("_", ":") for name in os.listdir(output_dir_positive)

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -11,6 +11,7 @@ from argparse import Namespace
 import joblib
 import numpy as np
 import requests.exceptions
+import scipy.sparse as sp
 from gensim.models import KeyedVectors
 
 from utils.abc_utils import download_md_files_for_references, send_classification_tag_to_abc, \
@@ -21,7 +22,7 @@ from utils.abc_utils import download_md_files_for_references, send_classificatio
     get_cached_mod_id_from_abbreviation, send_manual_indexing_to_abc, create_workflow_tag, \
     get_current_workflow_status
 from utils.get_documents import get_documents, remove_stopwords
-from utils.embedding import load_embedding_model, get_document_embedding
+from utils.embedding import load_embedding_model, build_document_features, get_bow_vectorizer
 
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 
@@ -41,12 +42,13 @@ def configure_logging(log_level):
 
 
 def classify_documents(input_docs_dir: str, embedding_model_path: str = None, classifier_model_path: str = None,
-                       embedding_model=None, classifier_model=None):
+                       embedding_model=None, classifier_model=None,
+                       use_bow_features: bool = False, use_max_pooling: bool = False):
     if embedding_model is None:
         embedding_model = load_embedding_model(model_path=embedding_model_path)
     if classifier_model is None:
         classifier_model = joblib.load(classifier_model_path)
-    X = []
+    rows = []
     files_loaded = []
     valid_embeddings = []
 
@@ -54,25 +56,34 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
 
     if isinstance(embedding_model, KeyedVectors):
         word_to_index = embedding_model.key_to_index
+        embedding_dim = embedding_model.vector_size
     else:
         word_to_index = {word: idx for idx, word in enumerate(embedding_model.get_words())}
+        embedding_dim = embedding_model.get_dimension()
+    bow_vectorizer = get_bow_vectorizer() if use_bow_features else None
 
     for _, (file_path, fulltext, _, _) in enumerate(documents):
         text = remove_stopwords(fulltext)
         text = text.lower()
-        doc_embedding = get_document_embedding(embedding_model, text, word_to_index=word_to_index)
-        X.append(doc_embedding)
+        features = build_document_features(embedding_model, text, use_max_pooling=use_max_pooling,
+                                           use_bow=use_bow_features, word_to_index=word_to_index,
+                                           bow_vectorizer=bow_vectorizer)
+        rows.append(features)
         files_loaded.append(file_path)
-        valid_embeddings.append(not np.all(doc_embedding == np.zeros_like(doc_embedding)))
+        # The "valid embedding" gate stays tied to the mean-embedding block (first
+        # embedding_dim dims); the optional max/BoW blocks do not change which
+        # documents are considered classifiable.
+        mean_block = features[0, :embedding_dim].toarray().ravel() if use_bow_features else features[:embedding_dim]
+        valid_embeddings.append(not np.all(mean_block == 0))
 
     del embedding_model
-    X = np.array(X)
-    if X.size == 0:
+    if not files_loaded:
         logger.warning(
             "classify_documents called with zero loaded documents for input_docs_dir=%s; "
             "skipping predict()", input_docs_dir,
         )
         return files_loaded, np.array([]), [], valid_embeddings
+    X = sp.vstack(rows, format="csr") if use_bow_features else np.vstack(rows)
     classifications = classifier_model.predict(X)
     try:
         confidence_scores = [classes_proba[1] for classes_proba in classifier_model.predict_proba(X)]
@@ -94,11 +105,18 @@ def parse_arguments():
     parser.add_argument("--test_mode", action="store_true", help="Run in test mode (directly on provided"
                                                                  " references and mod - do not store results nor send "
                                                                  "emails).", required=False)
+    parser.add_argument("--use_bow_features", action="store_true",
+                        help="Concatenate a stateless hashing bag-of-words block with the embedding. "
+                             "Must match the flag used when the model was trained.", required=False)
+    parser.add_argument("--use_max_pooling", action="store_true",
+                        help="Concatenate an element-wise max-pooled embedding alongside the mean. "
+                             "Must match the flag used when the model was trained.", required=False)
 
     return parser.parse_args()
 
 
-def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=False):
+def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=False,
+                                use_bow_features=False, use_max_pooling=False):
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
     tet_source_id = get_tet_source_id(mod_abbreviation=mod_abbr, source_method="abc_document_classifier",
                                       source_description="Alliance document classification pipeline using machine "
@@ -141,11 +159,11 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
         logger.info(f"Processing a batch of {str(len(job_batch))} jobs. "
                     f"Jobs remaining to process: {str(len(jobs_to_process))}")
         process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
-                          test_mode)
+                          test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling)
 
 
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
-                      test_mode):
+                      test_mode, use_bow_features=False, use_max_pooling=False):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     prepare_classification_directory()
     download_md_files_for_references(list(reference_curie_job_map.keys()),
@@ -171,7 +189,9 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
     files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
         embedding_model=embedding_model,
         classifier_model=classifier_model,
-        input_docs_dir="/data/agr_document_classifier/to_classify")
+        input_docs_dir="/data/agr_document_classifier/to_classify",
+        use_bow_features=use_bow_features,
+        use_max_pooling=use_max_pooling)
     if test_mode:
         for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                           valid_embeddings):
@@ -268,7 +288,9 @@ def classify_mode(args: Namespace):
     failed_processes = []
     for (mod_id, topic), jobs in mod_topic_jobs.items():
         try:
-            process_classification_jobs(mod_id, topic, jobs, embedding_model)
+            process_classification_jobs(mod_id, topic, jobs, embedding_model,
+                                        use_bow_features=args.use_bow_features,
+                                        use_max_pooling=args.use_max_pooling)
         except Exception as e:
             logger.error(f"Error processing a batch of '{topic}' jobs for {mod_id}: {e}")
             failed = {'topic': topic,
@@ -318,7 +340,9 @@ def direct_classify_mode(args: Namespace):
             topic=args.topic,
             jobs=jobs,
             embedding_model=embedding_model,
-            test_mode=True
+            test_mode=True,
+            use_bow_features=args.use_bow_features,
+            use_max_pooling=args.use_max_pooling
         )
     except Exception as e:
         logger.error(f"Error in direct classification: {e}")

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -43,7 +43,8 @@ def configure_logging(log_level):
 
 def classify_documents(input_docs_dir: str, embedding_model_path: str = None, classifier_model_path: str = None,
                        embedding_model=None, classifier_model=None,
-                       use_bow_features: bool = False, use_max_pooling: bool = False):
+                       use_bow_features: bool = False, use_max_pooling: bool = False,
+                       include_keywords: bool = False, include_metadata: bool = False):
     if embedding_model is None:
         embedding_model = load_embedding_model(model_path=embedding_model_path)
     if classifier_model is None:
@@ -52,7 +53,8 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
     files_loaded = []
     valid_embeddings = []
 
-    documents = get_documents(input_docs_dir=input_docs_dir)
+    documents = get_documents(input_docs_dir=input_docs_dir, include_keywords=include_keywords,
+                              include_metadata=include_metadata)
 
     if isinstance(embedding_model, KeyedVectors):
         word_to_index = embedding_model.key_to_index
@@ -111,12 +113,19 @@ def parse_arguments():
     parser.add_argument("--use_max_pooling", action="store_true",
                         help="Concatenate an element-wise max-pooled embedding alongside the mean. "
                              "Must match the flag used when the model was trained.", required=False)
+    parser.add_argument("--include_keywords", action="store_true",
+                        help="Include author keywords in the document text. "
+                             "Must match the flag used when the model was trained.", required=False)
+    parser.add_argument("--include_metadata", action="store_true",
+                        help="Include article metadata in the document text. "
+                             "Must match the flag used when the model was trained.", required=False)
 
     return parser.parse_args()
 
 
 def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=False,
-                                use_bow_features=False, use_max_pooling=False):
+                                use_bow_features=False, use_max_pooling=False,
+                                include_keywords=False, include_metadata=False):
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
     tet_source_id = get_tet_source_id(mod_abbreviation=mod_abbr, source_method="abc_document_classifier",
                                       source_description="Alliance document classification pipeline using machine "
@@ -159,11 +168,13 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
         logger.info(f"Processing a batch of {str(len(job_batch))} jobs. "
                     f"Jobs remaining to process: {str(len(jobs_to_process))}")
         process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
-                          test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling)
+                          test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling,
+                          include_keywords=include_keywords, include_metadata=include_metadata)
 
 
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
-                      test_mode, use_bow_features=False, use_max_pooling=False):
+                      test_mode, use_bow_features=False, use_max_pooling=False,
+                      include_keywords=False, include_metadata=False):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     prepare_classification_directory()
     download_md_files_for_references(list(reference_curie_job_map.keys()),
@@ -191,7 +202,9 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
         classifier_model=classifier_model,
         input_docs_dir="/data/agr_document_classifier/to_classify",
         use_bow_features=use_bow_features,
-        use_max_pooling=use_max_pooling)
+        use_max_pooling=use_max_pooling,
+        include_keywords=include_keywords,
+        include_metadata=include_metadata)
     if test_mode:
         for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                           valid_embeddings):
@@ -290,7 +303,9 @@ def classify_mode(args: Namespace):
         try:
             process_classification_jobs(mod_id, topic, jobs, embedding_model,
                                         use_bow_features=args.use_bow_features,
-                                        use_max_pooling=args.use_max_pooling)
+                                        use_max_pooling=args.use_max_pooling,
+                                        include_keywords=args.include_keywords,
+                                        include_metadata=args.include_metadata)
         except Exception as e:
             logger.error(f"Error processing a batch of '{topic}' jobs for {mod_id}: {e}")
             failed = {'topic': topic,
@@ -342,7 +357,9 @@ def direct_classify_mode(args: Namespace):
             embedding_model=embedding_model,
             test_mode=True,
             use_bow_features=args.use_bow_features,
-            use_max_pooling=args.use_max_pooling
+            use_max_pooling=args.use_max_pooling,
+            include_keywords=args.include_keywords,
+            include_metadata=args.include_metadata
         )
     except Exception as e:
         logger.error(f"Error in direct classification: {e}")

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -44,6 +44,7 @@ def configure_logging(log_level):
 def classify_documents(input_docs_dir: str, embedding_model_path: str = None, classifier_model_path: str = None,
                        embedding_model=None, classifier_model=None,
                        use_bow_features: bool = False, use_max_pooling: bool = False,
+                       use_lsh_features: bool = False,
                        include_keywords: bool = False, include_metadata: bool = False):
     if embedding_model is None:
         embedding_model = load_embedding_model(model_path=embedding_model_path)
@@ -63,19 +64,21 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
         word_to_index = {word: idx for idx, word in enumerate(embedding_model.get_words())}
         embedding_dim = embedding_model.get_dimension()
     bow_vectorizer = get_bow_vectorizer() if use_bow_features else None
+    # The LSH and BoW blocks both make the feature row sparse.
+    sparse_features = use_bow_features or use_lsh_features
 
     for _, (file_path, fulltext, _, _) in enumerate(documents):
         text = remove_stopwords(fulltext)
         text = text.lower()
         features = build_document_features(embedding_model, text, use_max_pooling=use_max_pooling,
-                                           use_bow=use_bow_features, word_to_index=word_to_index,
-                                           bow_vectorizer=bow_vectorizer)
+                                           use_bow=use_bow_features, use_lsh=use_lsh_features,
+                                           word_to_index=word_to_index, bow_vectorizer=bow_vectorizer)
         rows.append(features)
         files_loaded.append(file_path)
         # The "valid embedding" gate stays tied to the mean-embedding block (first
-        # embedding_dim dims); the optional max/BoW blocks do not change which
+        # embedding_dim dims); the optional max/LSH/BoW blocks do not change which
         # documents are considered classifiable.
-        mean_block = features[0, :embedding_dim].toarray().ravel() if use_bow_features else features[:embedding_dim]
+        mean_block = features[0, :embedding_dim].toarray().ravel() if sparse_features else features[:embedding_dim]
         valid_embeddings.append(not np.all(mean_block == 0))
 
     del embedding_model
@@ -85,7 +88,7 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
             "skipping predict()", input_docs_dir,
         )
         return files_loaded, np.array([]), [], valid_embeddings
-    X = sp.vstack(rows, format="csr") if use_bow_features else np.vstack(rows)
+    X = sp.vstack(rows, format="csr") if sparse_features else np.vstack(rows)
     classifications = classifier_model.predict(X)
     try:
         confidence_scores = [classes_proba[1] for classes_proba in classifier_model.predict_proba(X)]
@@ -113,6 +116,10 @@ def parse_arguments():
     parser.add_argument("--use_max_pooling", action="store_true",
                         help="Concatenate an element-wise max-pooled embedding alongside the mean. "
                              "Must match the flag used when the model was trained.", required=False)
+    parser.add_argument("--use_lsh_features", action="store_true",
+                        help="Concatenate a stateless LSH bag-of-concepts block (random-hyperplane "
+                             "buckets over the word embeddings). "
+                             "Must match the flag used when the model was trained.", required=False)
     parser.add_argument("--include_keywords", action="store_true",
                         help="Include author keywords in the document text. "
                              "Must match the flag used when the model was trained.", required=False)
@@ -124,7 +131,7 @@ def parse_arguments():
 
 
 def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=False,
-                                use_bow_features=False, use_max_pooling=False,
+                                use_bow_features=False, use_max_pooling=False, use_lsh_features=False,
                                 include_keywords=False, include_metadata=False):
     mod_abbr = get_cached_mod_abbreviation_from_id(mod_id)
     tet_source_id = get_tet_source_id(mod_abbreviation=mod_abbr, source_method="abc_document_classifier",
@@ -169,11 +176,12 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
                     f"Jobs remaining to process: {str(len(jobs_to_process))}")
         process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
                           test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling,
+                          use_lsh_features=use_lsh_features,
                           include_keywords=include_keywords, include_metadata=include_metadata)
 
 
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
-                      test_mode, use_bow_features=False, use_max_pooling=False,
+                      test_mode, use_bow_features=False, use_max_pooling=False, use_lsh_features=False,
                       include_keywords=False, include_metadata=False):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     prepare_classification_directory()
@@ -203,6 +211,7 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
         input_docs_dir="/data/agr_document_classifier/to_classify",
         use_bow_features=use_bow_features,
         use_max_pooling=use_max_pooling,
+        use_lsh_features=use_lsh_features,
         include_keywords=include_keywords,
         include_metadata=include_metadata)
     if test_mode:
@@ -304,6 +313,7 @@ def classify_mode(args: Namespace):
             process_classification_jobs(mod_id, topic, jobs, embedding_model,
                                         use_bow_features=args.use_bow_features,
                                         use_max_pooling=args.use_max_pooling,
+                                        use_lsh_features=args.use_lsh_features,
                                         include_keywords=args.include_keywords,
                                         include_metadata=args.include_metadata)
         except Exception as e:
@@ -358,6 +368,7 @@ def direct_classify_mode(args: Namespace):
             test_mode=True,
             use_bow_features=args.use_bow_features,
             use_max_pooling=args.use_max_pooling,
+            use_lsh_features=args.use_lsh_features,
             include_keywords=args.include_keywords,
             include_metadata=args.include_metadata
         )

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -23,6 +23,7 @@ from agr_dataset_manager.dataset_downloader import download_md_files_from_abc_or
 from models import POSSIBLE_CLASSIFIERS
 from utils.abc_utils import get_training_set_from_abc, upload_ml_model, get_reference_date
 from utils.embedding import load_embedding_model, build_feature_matrix
+from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
 
 nltk.download('stopwords')
@@ -441,53 +442,34 @@ def download_training_set(args, training_data_dir):
     if args.filter_date_before:
         try:
             filter_date = datetime.strptime(args.filter_date_before, "%Y-%m-%d")
-            logger.info(f"Filtering out references published before {args.filter_date_before}")
-
-            # Filter positive references
-            filtered_positive = []
-            for ref_id in reference_ids_positive:
-                ref_date_str = get_reference_date(ref_id)
-                if ref_date_str:
-                    try:
-                        ref_date = datetime.strptime(ref_date_str[:10], "%Y-%m-%d")  # Take only date part
-                        if ref_date >= filter_date:
-                            filtered_positive.append(ref_id)
-                        else:
-                            logger.debug(f"Filtering out {ref_id} (published {ref_date_str})")
-                    except ValueError:
-                        logger.warning(f"Could not parse date '{ref_date_str}' for reference {ref_id}, including it")
-                        filtered_positive.append(ref_id)
-                else:
-                    logger.debug(f"No date found for reference {ref_id}, including it")
-                    filtered_positive.append(ref_id)
-
-            # Filter negative references
-            filtered_negative = []
-            for ref_id in reference_ids_negative:
-                ref_date_str = get_reference_date(ref_id)
-                if ref_date_str:
-                    try:
-                        ref_date = datetime.strptime(ref_date_str[:10], "%Y-%m-%d")  # Take only date part
-                        if ref_date >= filter_date:
-                            filtered_negative.append(ref_id)
-                        else:
-                            logger.debug(f"Filtering out {ref_id} (published {ref_date_str})")
-                    except ValueError:
-                        logger.warning(f"Could not parse date '{ref_date_str}' for reference {ref_id}, including it")
-                        filtered_negative.append(ref_id)
-                else:
-                    logger.debug(f"No date found for reference {ref_id}, including it")
-                    filtered_negative.append(ref_id)
-
-            logger.info(f"Date filtering complete. Positive: {len(reference_ids_positive)} -> "
-                        f"{len(filtered_positive)}, Negative: {len(reference_ids_negative)} -> "
-                        f"{len(filtered_negative)}")
-            reference_ids_positive = filtered_positive
-            reference_ids_negative = filtered_negative
-
         except ValueError:
             logger.error(f"Invalid date format: {args.filter_date_before}. Expected YYYY-MM-DD")
             raise
+        logger.info(f"Filtering out references published before {args.filter_date_before}")
+
+        def _keep_on_or_after(ref_ids):
+            """Keep references published on/after filter_date. References whose
+            (possibly messy PubMed) date cannot be parsed at all are kept."""
+            kept = []
+            for ref_id in ref_ids:
+                ref_date_str = get_reference_date(ref_id)
+                ref_date = parse_reference_date(ref_date_str)
+                if ref_date is None:
+                    logger.debug(f"No parseable date for {ref_id} ('{ref_date_str}'), including it")
+                    kept.append(ref_id)
+                elif ref_date >= filter_date:
+                    kept.append(ref_id)
+                else:
+                    logger.debug(f"Filtering out {ref_id} (published {ref_date_str})")
+            return kept
+
+        filtered_positive = _keep_on_or_after(reference_ids_positive)
+        filtered_negative = _keep_on_or_after(reference_ids_negative)
+        logger.info(f"Date filtering complete. Positive: {len(reference_ids_positive)} -> "
+                    f"{len(filtered_positive)}, Negative: {len(reference_ids_negative)} -> "
+                    f"{len(filtered_negative)}")
+        reference_ids_positive = filtered_positive
+        reference_ids_negative = filtered_negative
 
     shutil.rmtree(os.path.join(training_data_dir, "positive"), ignore_errors=True)
     shutil.rmtree(os.path.join(training_data_dir, "negative"), ignore_errors=True)

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -93,7 +93,8 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
                      standardize_embeddings: bool = False, normalize_embeddings: bool = False,
                      sections_to_use: List[str] = None, remove_outliers: bool = False,
                      outlier_method: str = 'isolation_forest', outlier_contamination: float = 0.1,
-                     use_bow_features: bool = False, use_max_pooling: bool = False):
+                     use_bow_features: bool = False, use_max_pooling: bool = False,
+                     include_keywords: bool = False, include_metadata: bool = False):
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 
     texts = []
@@ -108,7 +109,10 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     # For each document in your training data, collect its text and label
     logger.info("Loading training set")
     for label in ["positive", "negative"]:
-        documents = list(get_documents(os.path.join(training_data_dir, label)))
+        documents = list(get_documents(
+            os.path.join(training_data_dir, label),
+            include_keywords=include_keywords,
+            include_metadata=include_metadata))
 
         for _, (_, fulltext, title, abstract) in enumerate(documents, start=1):
             text = ""
@@ -397,6 +401,14 @@ def parse_arguments():
                         help="Concatenate an element-wise max-pooled embedding alongside the mean "
                              "(must be passed identically at classification time)",
                         required=False)
+    parser.add_argument("--include_keywords", action="store_true",
+                        help="Include author keywords in the document text (off by default; must be "
+                             "passed identically at classification time)",
+                        required=False)
+    parser.add_argument("--include_metadata", action="store_true",
+                        help="Include article metadata in the document text (off by default; must be "
+                             "passed identically at classification time)",
+                        required=False)
     parser.add_argument("-S", "--skip_training_set_download", action="store_true",
                         help="Assume that tei files from training set are already present and do not download them "
                              "again",
@@ -522,7 +534,9 @@ def train_and_save_model(args, training_data_dir, training_set):
         outlier_method=args.outlier_method,
         outlier_contamination=args.outlier_contamination,
         use_bow_features=args.use_bow_features,
-        use_max_pooling=args.use_max_pooling)
+        use_max_pooling=args.use_max_pooling,
+        include_keywords=args.include_keywords,
+        include_metadata=args.include_metadata)
     logger.info(f"Best classifier stats: {str(stats)}")
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -22,7 +22,7 @@ from sklearn.neighbors import LocalOutlierFactor
 from agr_dataset_manager.dataset_downloader import download_md_files_from_abc_or_convert_pdf
 from models import POSSIBLE_CLASSIFIERS
 from utils.abc_utils import get_training_set_from_abc, upload_ml_model, get_reference_date
-from utils.embedding import load_embedding_model, get_document_embedding
+from utils.embedding import load_embedding_model, build_feature_matrix
 from utils.get_documents import get_documents, remove_stopwords
 
 nltk.download('stopwords')
@@ -89,10 +89,11 @@ def detect_and_remove_outliers(X, y, method='isolation_forest', contamination=0.
 def train_classifier(embedding_model_path: str, training_data_dir: str, weighted_average_word_embedding: bool = False,
                      standardize_embeddings: bool = False, normalize_embeddings: bool = False,
                      sections_to_use: List[str] = None, remove_outliers: bool = False,
-                     outlier_method: str = 'isolation_forest', outlier_contamination: float = 0.1):
+                     outlier_method: str = 'isolation_forest', outlier_contamination: float = 0.1,
+                     use_bow_features: bool = False, use_max_pooling: bool = False):
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 
-    X = []
+    texts = []
     y = []
 
     # Precompute word_to_index
@@ -101,7 +102,7 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     else:
         word_to_index = {word: idx for idx, word in enumerate(embedding_model.get_words())}
 
-    # For each document in your training data, extract embeddings and labels
+    # For each document in your training data, collect its text and label
     logger.info("Loading training set")
     for label in ["positive", "negative"]:
         documents = list(get_documents(os.path.join(training_data_dir, label)))
@@ -120,20 +121,20 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
             if text:
                 text = remove_stopwords(text)
                 text = text.lower()
-                text_embedding = get_document_embedding(embedding_model, text,
-                                                        weighted_average_word_embedding=weighted_average_word_embedding,
-                                                        standardize_embeddings=standardize_embeddings,
-                                                        normalize_embeddings=normalize_embeddings,
-                                                        word_to_index=word_to_index)
-                X.append(text_embedding)
+                texts.append(text)
                 y.append(int(label == "positive"))
+
+    logger.info(f"Building features (max_pooling={use_max_pooling}, bow={use_bow_features}).")
+    X = build_feature_matrix(embedding_model, texts, use_max_pooling=use_max_pooling,
+                             use_bow=use_bow_features,
+                             weighted_average_word_embedding=weighted_average_word_embedding,
+                             standardize_embeddings=standardize_embeddings,
+                             normalize_embeddings=normalize_embeddings, word_to_index=word_to_index)
 
     del embedding_model
     logger.info("Finished loading training set.")
-    logger.info(f"Dataset size: {str(len(X))}")
+    logger.info(f"Dataset size: {str(len(y))}")
 
-    # Convert lists to numpy arrays
-    X = np.array(X)
     y = np.array(y)
 
     # Step 1: Split data into train+val (80%) and holdout test set (20%)
@@ -174,6 +175,11 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     logger.info("Using penalized scoring: weighted_score = 0.7 * test_f1 + 0.3 * cv_f1 - penalty")
 
     for classifier_name, classifier_info in POSSIBLE_CLASSIFIERS.items():
+        # RBF-SVC is slow and weak on the high-dimensional sparse matrix produced
+        # by the BoW block, so skip it when BoW features are enabled.
+        if use_bow_features and classifier_name == 'SVC':
+            logger.info("Skipping SVC: not suitable for the high-dim sparse BoW feature matrix.")
+            continue
         logger.info(f"Evaluating model {classifier_name}.")
 
         # Reduce n_iter for faster training with focus on regularization
@@ -375,6 +381,14 @@ def parse_arguments():
     parser.add_argument("-s", "--standardize_embeddings", action="store_true",
                         help="Whether to standardize the word embedding vectors",
                         required=False)
+    parser.add_argument("--use_bow_features", action="store_true",
+                        help="Concatenate a stateless hashing bag-of-words block with the embedding "
+                             "(must be passed identically at classification time)",
+                        required=False)
+    parser.add_argument("--use_max_pooling", action="store_true",
+                        help="Concatenate an element-wise max-pooled embedding alongside the mean "
+                             "(must be passed identically at classification time)",
+                        required=False)
     parser.add_argument("-S", "--skip_training_set_download", action="store_true",
                         help="Assume that tei files from training set are already present and do not download them "
                              "again",
@@ -517,7 +531,9 @@ def train_and_save_model(args, training_data_dir, training_set):
         sections_to_use=args.sections_to_use,
         remove_outliers=args.remove_outliers,
         outlier_method=args.outlier_method,
-        outlier_contamination=args.outlier_contamination)
+        outlier_contamination=args.outlier_contamination,
+        use_bow_features=args.use_bow_features,
+        use_max_pooling=args.use_max_pooling)
     logger.info(f"Best classifier stats: {str(stats)}")
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -67,7 +67,7 @@ def detect_and_remove_outliers(X, y, method='isolation_forest', contamination=0.
         detector = LocalOutlierFactor(contamination=contamination, novelty=False)
     else:
         logger.warning(f"Unknown outlier detection method: {method}. Skipping outlier removal.")
-        return X, y, np.ones(len(X), dtype=bool)
+        return X, y, np.ones(X.shape[0], dtype=bool)
 
     # Fit the detector and predict outliers
     outlier_predictions = detector.fit_predict(X)
@@ -81,8 +81,10 @@ def detect_and_remove_outliers(X, y, method='isolation_forest', contamination=0.
     y_clean = y[inlier_mask]
 
     n_outliers = np.sum(outlier_mask)
-    logger.info(f"Removed {n_outliers} outliers ({n_outliers/len(X)*100:.1f}%) from {len(X)} samples")
-    logger.info(f"Remaining samples: {len(X_clean)} (Positive: {np.sum(y_clean)}, Negative: {np.sum(1-y_clean)})")
+    logger.info(f"Removed {n_outliers} outliers ({n_outliers / X.shape[0] * 100:.1f}%) "
+                f"from {X.shape[0]} samples")
+    logger.info(f"Remaining samples: {X_clean.shape[0]} "
+                f"(Positive: {np.sum(y_clean)}, Negative: {np.sum(1 - y_clean)})")
 
     return X_clean, y_clean, outlier_mask
 
@@ -143,7 +145,8 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
         X, y, test_size=0.20, stratify=y, random_state=42
     )
 
-    logger.info(f"Dataset split - Total: {len(X)}, Train+Val: {len(X_train_val)}, Test: {len(X_test)}")
+    logger.info(f"Dataset split - Total: {X.shape[0]}, Train+Val: {X_train_val.shape[0]}, "
+                f"Test: {X_test.shape[0]}")
     logger.info(f"Class distribution - Train+Val: {np.bincount(y_train_val)}, Test: {np.bincount(y_test)}")
 
     # Step 2: Apply outlier detection and removal if requested

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -179,10 +179,14 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     logger.info("Using penalized scoring: weighted_score = 0.7 * test_f1 + 0.3 * cv_f1 - penalty")
 
     for classifier_name, classifier_info in POSSIBLE_CLASSIFIERS.items():
-        # RBF-SVC is slow and weak on the high-dimensional sparse matrix produced
-        # by the BoW block, so skip it when BoW features are enabled.
-        if use_bow_features and classifier_name == 'SVC':
-            logger.info("Skipping SVC: not suitable for the high-dim sparse BoW feature matrix.")
+        # On the high-dimensional sparse matrix produced by the BoW block, RBF-SVC
+        # is slow/weak and MLPClassifier is both memory-heavy (its input-layer
+        # weight matrix is n_features x hidden, ~210MB at 2**18 features, multiplied
+        # across RandomizedSearchCV's parallel workers -> OOM) and prone to severe
+        # overfitting. Skip both when BoW features are enabled.
+        if use_bow_features and classifier_name in ('SVC', 'MLPClassifier'):
+            logger.info(f"Skipping {classifier_name}: not suitable for the high-dimensional sparse "
+                        f"BoW feature matrix.")
             continue
         logger.info(f"Evaluating model {classifier_name}.")
 

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -94,6 +94,7 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
                      sections_to_use: List[str] = None, remove_outliers: bool = False,
                      outlier_method: str = 'isolation_forest', outlier_contamination: float = 0.1,
                      use_bow_features: bool = False, use_max_pooling: bool = False,
+                     use_lsh_features: bool = False,
                      include_keywords: bool = False, include_metadata: bool = False):
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 
@@ -131,9 +132,10 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
                 texts.append(text)
                 y.append(int(label == "positive"))
 
-    logger.info(f"Building features (max_pooling={use_max_pooling}, bow={use_bow_features}).")
+    logger.info(f"Building features (max_pooling={use_max_pooling}, bow={use_bow_features}, "
+                f"lsh={use_lsh_features}).")
     X = build_feature_matrix(embedding_model, texts, use_max_pooling=use_max_pooling,
-                             use_bow=use_bow_features,
+                             use_bow=use_bow_features, use_lsh=use_lsh_features,
                              weighted_average_word_embedding=weighted_average_word_embedding,
                              standardize_embeddings=standardize_embeddings,
                              normalize_embeddings=normalize_embeddings, word_to_index=word_to_index)
@@ -401,6 +403,11 @@ def parse_arguments():
                         help="Concatenate an element-wise max-pooled embedding alongside the mean "
                              "(must be passed identically at classification time)",
                         required=False)
+    parser.add_argument("--use_lsh_features", action="store_true",
+                        help="Concatenate a stateless LSH bag-of-concepts block (random-hyperplane "
+                             "buckets over the word embeddings, so near-synonyms share a bin) with the "
+                             "embedding (must be passed identically at classification time)",
+                        required=False)
     parser.add_argument("--include_keywords", action="store_true",
                         help="Include author keywords in the document text (off by default; must be "
                              "passed identically at classification time)",
@@ -535,6 +542,7 @@ def train_and_save_model(args, training_data_dir, training_set):
         outlier_contamination=args.outlier_contamination,
         use_bow_features=args.use_bow_features,
         use_max_pooling=args.use_max_pooling,
+        use_lsh_features=args.use_lsh_features,
         include_keywords=args.include_keywords,
         include_metadata=args.include_metadata)
     logger.info(f"Best classifier stats: {str(stats)}")

--- a/agr_document_classifier/models.py
+++ b/agr_document_classifier/models.py
@@ -1,9 +1,10 @@
+from lightgbm import LGBMClassifier
 from scipy.stats import loguniform, randint, uniform
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression, SGDClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.neural_network import MLPClassifier
-from sklearn.svm import SVC
+from sklearn.svm import SVC, LinearSVC
 from sklearn.tree import DecisionTreeClassifier
 from xgboost import XGBClassifier
 
@@ -27,6 +28,45 @@ POSSIBLE_CLASSIFIERS = {
                 'warm_start': [False]
             }
         ]
+    },
+    'LinearSVC': {
+        # Scalable linear SVM (liblinear/saga) — handles the high-dimensional
+        # sparse BoW matrix cheaply, unlike the libsvm-based SVC. No predict_proba;
+        # the classify pipeline falls back to decision_function -> sigmoid.
+        'model': LinearSVC(random_state=42, max_iter=5000),
+        'params': [
+            {
+                'C': loguniform(1e-3, 10),
+                'penalty': ['l2'],
+                'loss': ['squared_hinge', 'hinge'],
+                'dual': [True],
+                'class_weight': ['balanced'],
+            },
+            {
+                'C': loguniform(1e-3, 10),
+                'penalty': ['l1'],
+                'loss': ['squared_hinge'],
+                'dual': [False],
+                'class_weight': ['balanced'],
+            },
+        ]
+    },
+    'LGBMClassifier': {
+        # LightGBM gradient boosting — sparse-native and typically >= XGBoost.
+        # subsample_freq=1 makes the sampled `subsample` (bagging) actually apply.
+        'model': LGBMClassifier(random_state=42, verbose=-1, subsample_freq=1),
+        'params': {
+            'n_estimators': randint(50, 200),
+            'num_leaves': randint(15, 63),
+            'max_depth': [-1, 3, 5, 7],
+            'learning_rate': loguniform(0.01, 0.3),
+            'min_child_samples': randint(5, 40),
+            'subsample': uniform(0.6, 0.4),         # bagging fraction (0.6-1.0)
+            'colsample_bytree': uniform(0.5, 0.5),  # feature fraction (0.5-1.0)
+            'reg_alpha': loguniform(1e-3, 10),      # L1
+            'reg_lambda': loguniform(1e-3, 10),     # L2
+            'class_weight': ['balanced', None],
+        }
     },
     'RandomForestClassifier': {
         'model': RandomForestClassifier(random_state=42),

--- a/tests/agr_dataset_manager/test_dataset_downloader.py
+++ b/tests/agr_dataset_manager/test_dataset_downloader.py
@@ -1,0 +1,25 @@
+"""Tests for the training-set MD downloader.
+
+When building a training set we must NOT trigger on-demand server-side
+conversion: a reference with no MD/TEI means its upload/conversion is not
+complete, and it should simply be excluded from the training set.
+"""
+
+import os
+from unittest.mock import patch
+
+from agr_dataset_manager import dataset_downloader
+
+
+@patch("agr_dataset_manager.dataset_downloader.download_md_files_for_references")
+def test_training_download_does_not_request_on_demand_conversion(mock_dl, tmp_path):
+    os.makedirs(tmp_path / "positive", exist_ok=True)
+    os.makedirs(tmp_path / "negative", exist_ok=True)
+
+    dataset_downloader.download_md_files_from_abc_or_convert_pdf(
+        ["AGRKB:1"], ["AGRKB:2"], str(tmp_path), "WB",
+    )
+
+    assert mock_dl.call_count == 2
+    for call in mock_dl.call_args_list:
+        assert call.kwargs.get("request_conversion") is False

--- a/tests/agr_document_classifier/test_models.py
+++ b/tests/agr_document_classifier/test_models.py
@@ -1,0 +1,36 @@
+"""Tests for the classifier model zoo (POSSIBLE_CLASSIFIERS).
+
+LinearSVC and LGBMClassifier were added as sparse-friendly models that can run
+on the high-dimensional BoW feature matrix (where rbf-SVC and MLP are skipped).
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from sklearn.metrics import f1_score, make_scorer
+from sklearn.model_selection import RandomizedSearchCV
+
+from agr_document_classifier.models import POSSIBLE_CLASSIFIERS
+
+
+def test_new_sparse_friendly_models_present():
+    assert "LinearSVC" in POSSIBLE_CLASSIFIERS
+    assert "LGBMClassifier" in POSSIBLE_CLASSIFIERS
+
+
+@pytest.mark.parametrize("name", ["LinearSVC", "LGBMClassifier"])
+def test_new_models_search_fits_on_sparse_input(name):
+    """Every sampled hyperparameter combination must be valid and the model
+    must fit/predict on a sparse (BoW-like) matrix."""
+    rng = np.random.RandomState(0)
+    X = sp.csr_matrix(rng.rand(40, 60))
+    y = np.array([0, 1] * 20)
+    info = POSSIBLE_CLASSIFIERS[name]
+    search = RandomizedSearchCV(
+        info["model"], info["params"], n_iter=5, cv=2,
+        scoring=make_scorer(f1_score, zero_division=0),
+        random_state=42, n_jobs=1,
+    )
+    search.fit(X, y)
+    preds = search.predict(X)
+    assert len(preds) == 40

--- a/tests/utils/test_classifier_features.py
+++ b/tests/utils/test_classifier_features.py
@@ -1,0 +1,124 @@
+"""Tests for the shared classifier feature builder (SCRUM-6132).
+
+Problem #2: mean-pooled BioWordVec dilutes decisive/rare tokens. These tests pin
+the behaviour of the optional, stateless feature blocks (max pooling + hashing
+BoW) and guarantee that the mean-only path is byte-for-byte unchanged.
+"""
+
+import numpy as np
+import scipy.sparse as sp
+from gensim.models import KeyedVectors
+
+from utils.embedding import (
+    BOW_CONFIG,
+    build_document_features,
+    build_feature_matrix,
+    get_document_embedding,
+)
+
+
+def _toy_model():
+    """A tiny in-memory KeyedVectors stand-in for BioWordVec."""
+    kv = KeyedVectors(vector_size=4)
+    kv.add_vectors(
+        ["gene", "expression", "control"],
+        np.array([
+            [1.0, 0.0, 2.0, -1.0],
+            [0.0, 3.0, 1.0, 0.5],
+            [-2.0, 1.0, 0.0, 4.0],
+        ], dtype=np.float32),
+    )
+    return kv
+
+
+# ---------------------------------------------------------------------------
+# Regression: mean-only path must equal the current implementation exactly
+# ---------------------------------------------------------------------------
+
+
+def test_mean_only_matches_get_document_embedding():
+    kv = _toy_model()
+    text = "gene expression control"
+    feats = build_document_features(kv, text)  # both flags default off
+    expected = get_document_embedding(kv, text)
+    assert isinstance(feats, np.ndarray)
+    assert np.allclose(feats, expected)
+    assert feats.shape == (4,)
+
+
+# ---------------------------------------------------------------------------
+# Max pooling
+# ---------------------------------------------------------------------------
+
+
+def test_max_pooling_appends_elementwise_max():
+    kv = _toy_model()
+    text = "gene expression control"
+    feats = build_document_features(kv, text, use_max_pooling=True)
+    assert feats.shape == (8,)
+    # First block is the mean, unchanged.
+    assert np.allclose(feats[:4], get_document_embedding(kv, text))
+    # Second block is the element-wise max over the valid word vectors.
+    stack = kv[["gene", "expression", "control"]]
+    assert np.allclose(feats[4:], stack.max(axis=0))
+
+
+# ---------------------------------------------------------------------------
+# BoW (hashing)
+# ---------------------------------------------------------------------------
+
+
+def test_bow_is_sparse_with_expected_width_and_deterministic():
+    kv = _toy_model()
+    text = "gene expression control"
+    feats = build_document_features(kv, text, use_bow=True)
+    assert sp.issparse(feats)
+    assert feats.shape == (1, 4 + BOW_CONFIG["n_features"])
+    # Stateless / deterministic: same input -> identical output, no fitting.
+    again = build_document_features(kv, text, use_bow=True)
+    assert (feats != again).nnz == 0
+
+
+def test_bow_captures_oov_token_that_embedding_drops():
+    kv = _toy_model()
+    base = build_document_features(kv, "gene", use_bow=True)
+    with_oov = build_document_features(kv, "gene fbal0001234", use_bow=True)
+    dim = 4
+    # The embedding (mean) block is identical: the OOV token contributes nothing.
+    assert np.allclose(base[:, :dim].toarray(), with_oov[:, :dim].toarray())
+    # But the BoW block gains the OOV token -> strictly more non-zeros.
+    assert with_oov[:, dim:].nnz > base[:, dim:].nnz
+
+
+def test_bow_combines_with_max_pooling_widths():
+    kv = _toy_model()
+    feats = build_document_features(kv, "gene expression", use_max_pooling=True, use_bow=True)
+    assert sp.issparse(feats)
+    assert feats.shape == (1, 8 + BOW_CONFIG["n_features"])
+
+
+# ---------------------------------------------------------------------------
+# All-OOV document: validity gate relies on the mean block being zeros
+# ---------------------------------------------------------------------------
+
+
+def test_all_oov_document_has_zero_mean_block():
+    kv = _toy_model()
+    feats = build_document_features(kv, "zzz qqq", use_max_pooling=True)
+    assert np.allclose(feats, np.zeros(8))
+
+
+# ---------------------------------------------------------------------------
+# Batch builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_feature_matrix_dense_and_sparse():
+    kv = _toy_model()
+    dense = build_feature_matrix(kv, ["gene expression", "control gene"])
+    assert isinstance(dense, np.ndarray)
+    assert dense.shape == (2, 4)
+
+    sparse = build_feature_matrix(kv, ["gene expression", "control gene"], use_bow=True)
+    assert sp.issparse(sparse)
+    assert sparse.shape == (2, 4 + BOW_CONFIG["n_features"])

--- a/tests/utils/test_classifier_features.py
+++ b/tests/utils/test_classifier_features.py
@@ -11,9 +11,11 @@ from gensim.models import KeyedVectors
 
 from utils.embedding import (
     BOW_CONFIG,
+    LSH_CONFIG,
     build_document_features,
     build_feature_matrix,
     get_document_embedding,
+    lsh_feature_width,
 )
 
 
@@ -95,6 +97,86 @@ def test_bow_combines_with_max_pooling_widths():
     feats = build_document_features(kv, "gene expression", use_max_pooling=True, use_bow=True)
     assert sp.issparse(feats)
     assert feats.shape == (1, 8 + BOW_CONFIG["n_features"])
+
+
+# ---------------------------------------------------------------------------
+# LSH bag-of-concepts (hash embeddings directly, no clustering)
+# ---------------------------------------------------------------------------
+
+
+def _directional_model():
+    """A model whose words point in controlled directions, so LSH bucket
+    assignment is fully deterministic:
+
+    - ``same`` is a positive multiple of ``base`` (identical direction) -> every
+      random hyperplane gives it the same sign -> identical buckets.
+    - ``opposite`` is ``-base`` -> every sign flips -> a disjoint set of buckets.
+    """
+    base = np.array([0.7, -1.3, 0.4, 2.1, -0.9, 0.2, 1.1, -0.5], dtype=np.float32)
+    kv = KeyedVectors(vector_size=8)
+    kv.add_vectors(["base", "same", "opposite"],
+                   np.array([base, 2.0 * base, -base], dtype=np.float32))
+    return kv
+
+
+def test_lsh_is_sparse_with_expected_width_and_deterministic():
+    kv = _toy_model()
+    text = "gene expression control"
+    feats = build_document_features(kv, text, use_lsh=True)
+    assert sp.issparse(feats)
+    assert feats.shape == (1, 4 + lsh_feature_width())
+    # Stateless / deterministic: same input -> identical output, no fitting.
+    again = build_document_features(kv, text, use_lsh=True)
+    assert (feats != again).nnz == 0
+    # Mean block is preserved as the (dense) front of the row.
+    assert np.allclose(feats[0, :4].toarray().ravel(), get_document_embedding(kv, text))
+
+
+def test_lsh_collides_codirectional_words_into_same_buckets():
+    kv = _directional_model()
+    dim = 8
+    n_tables = LSH_CONFIG["n_tables"]
+    base_only = build_document_features(kv, "base", use_lsh=True)[:, dim:]
+    co_directional = build_document_features(kv, "base same", use_lsh=True)[:, dim:]
+    opposite = build_document_features(kv, "base opposite", use_lsh=True)[:, dim:]
+
+    # A single word occupies exactly one bucket per table.
+    assert base_only.nnz == n_tables
+    # "same" points the same way as "base" -> they share every bucket: the set of
+    # occupied buckets is unchanged, only the counts double.
+    assert co_directional.nnz == n_tables
+    assert co_directional.sum() == 2 * n_tables
+    assert (co_directional.indices == base_only.indices).all()
+    # "opposite" flips every sign -> a disjoint set of buckets, so nnz doubles.
+    assert opposite.nnz == 2 * n_tables
+
+
+def test_lsh_combines_with_bow_and_max_pooling_widths():
+    kv = _toy_model()
+    # LSH together with BoW (the "both" experiment).
+    both = build_document_features(kv, "gene expression", use_lsh=True, use_bow=True)
+    assert sp.issparse(both)
+    assert both.shape == (1, 4 + lsh_feature_width() + BOW_CONFIG["n_features"])
+    # Block order is [mean | max | lsh | bow]: mean stays first for the gate.
+    full = build_document_features(kv, "gene expression", use_max_pooling=True,
+                                   use_lsh=True, use_bow=True)
+    assert full.shape == (1, 8 + lsh_feature_width() + BOW_CONFIG["n_features"])
+    assert np.allclose(full[0, :4].toarray().ravel(), get_document_embedding(kv, "gene expression"))
+
+
+def test_lsh_all_oov_document_is_zero_block_and_keeps_mean_gate():
+    kv = _toy_model()
+    feats = build_document_features(kv, "zzz qqq", use_lsh=True)
+    assert feats.shape == (1, 4 + lsh_feature_width())
+    # No in-vocabulary words -> empty LSH block and a zero mean block (the gate).
+    assert feats.nnz == 0
+
+
+def test_build_feature_matrix_lsh_is_sparse():
+    kv = _toy_model()
+    matrix = build_feature_matrix(kv, ["gene expression", "control gene"], use_lsh=True)
+    assert sp.issparse(matrix)
+    assert matrix.shape == (2, 4 + lsh_feature_width())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_date_utils.py
+++ b/tests/utils/test_date_utils.py
@@ -1,0 +1,54 @@
+"""Tests for robust reference-date parsing (training date filter)."""
+
+from datetime import datetime
+
+from utils.date_utils import parse_reference_date
+
+
+def test_iso_date():
+    assert parse_reference_date("2019-03-15") == datetime(2019, 3, 15)
+
+
+def test_iso_datetime_drops_time():
+    assert parse_reference_date("2019-03-15T10:30:00") == datetime(2019, 3, 15)
+
+
+def test_year_month():
+    assert parse_reference_date("2019-03") == datetime(2019, 3, 1)
+
+
+def test_year_only():
+    assert parse_reference_date("2019") == datetime(2019, 1, 1)
+
+
+def test_month_abbrev_then_year():
+    assert parse_reference_date("Mar 2019") == datetime(2019, 3, 1)
+
+
+def test_year_then_month_abbrev():
+    assert parse_reference_date("2019 Mar") == datetime(2019, 3, 1)
+
+
+def test_full_month_name():
+    assert parse_reference_date("March 2019") == datetime(2019, 3, 1)
+
+
+def test_pubmed_month_range_takes_first_month():
+    # "2019 Mar-Apr" -> first month of the range, day defaults to the 1st
+    assert parse_reference_date("2019 Mar-Apr") == datetime(2019, 3, 1)
+
+
+def test_season_falls_back_to_year():
+    # "Summer 2019" has no parseable month -> earliest instant of the year
+    assert parse_reference_date("Summer 2019") == datetime(2019, 1, 1)
+
+
+def test_none_and_empty_return_none():
+    assert parse_reference_date(None) is None
+    assert parse_reference_date("") is None
+    assert parse_reference_date("   ") is None
+
+
+def test_string_without_year_returns_none():
+    assert parse_reference_date("no date here") is None
+    assert parse_reference_date("Mar") is None

--- a/tests/utils/test_download_md_files.py
+++ b/tests/utils/test_download_md_files.py
@@ -159,6 +159,69 @@ def test_only_first_main_md_is_taken(mock_download, _req, mock_urlopen, _tok):
 @patch("utils.abc_utils.urllib.request.urlopen")
 @patch("utils.abc_utils.urllib.request.Request")
 @patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_uses_cross_mod_main_md_when_no_matching_or_global_md(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """A converted_merged_main MD is the paper's full text and is MOD-agnostic.
+    When the weekly conversion cron has scoped it to a specific MOD (e.g. WB)
+    and there is no own/global MD and no TEI, a run for another MOD (FB) must
+    still use it rather than report 'no MD/TEI'.
+    """
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 555,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# cross-mod md"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(["AGRKB:1"], tmp, "FB")
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 555
+        assert os.path.exists(os.path.join(tmp, "AGRKB_1.md"))
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+def test_prefers_matching_mod_md_over_cross_mod(
+    mock_download, _req, mock_urlopen, _tok,
+):
+    """When both a matching-MOD (or global) MD and a cross-MOD MD exist, the
+    matching/global one is still preferred; the cross-MOD MD is only a fallback.
+    """
+    ref_files = [
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 777,
+            "referencefile_mods": [{"mod_abbreviation": "MGI"}],
+        },
+        {
+            "file_extension": "md",
+            "file_class": "converted_merged_main",
+            "referencefile_id": 888,
+            "referencefile_mods": [{"mod_abbreviation": None}],  # global
+        },
+    ]
+    mock_urlopen.return_value = _show_all_response(ref_files)
+    mock_download.return_value = b"# md"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_md_files_for_references(["AGRKB:1"], tmp, "FB")
+        assert mock_download.call_count == 1
+        assert mock_download.call_args[0][0]["referencefile_id"] == 888
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
 def test_supplements_downloaded_when_opted_in(
     mock_download, _req, mock_urlopen, _tok,
 ):
@@ -321,13 +384,12 @@ def test_main_md_with_empty_referencefile_mods_is_used(
 @patch("utils.abc_utils.urllib.request.urlopen")
 @patch("utils.abc_utils.urllib.request.Request")
 @patch("utils.abc_utils.get_file_from_abc_reffile_obj")
-def test_main_md_scoped_to_other_mod_only_is_skipped(
+def test_cross_mod_main_md_preferred_over_tei(
     mock_download, _req, mock_urlopen, _tok,
 ):
-    """A converted_merged_main row scoped exclusively to a different MOD
-    must NOT be selected, even when the requested MOD has no MD. The
-    downloader should fall through to the TEI fallback for the requested
-    MOD."""
+    """A converted_merged_main MD is the paper's full text (MOD-agnostic), so
+    even when it is scoped to a different MOD it is used directly and preferred
+    over converting a TEI fallback for the requested MOD."""
     ref_files = [
         {
             "file_extension": "md",
@@ -343,19 +405,19 @@ def test_main_md_scoped_to_other_mod_only_is_skipped(
         },
     ]
     mock_urlopen.return_value = _show_all_response(ref_files)
-    tei_bytes = b"<TEI/>"
-    mock_download.return_value = tei_bytes
+    mock_download.return_value = b"# md from other mod"
 
-    with patch("agr_abc_document_parsers.convert_xml_to_markdown",
-               return_value="# from tei") as mock_convert:
+    with patch("agr_abc_document_parsers.convert_xml_to_markdown") as mock_convert:
         with tempfile.TemporaryDirectory() as tmp:
             abc_utils.download_md_files_for_references(
                 ["AGRKB:1"], tmp, "FB",
             )
-            # The MGI-only MD must not be downloaded; the FB TEI must be.
+            # The cross-MOD MD is used directly; the TEI is not converted.
             assert mock_download.call_count == 1
-            assert mock_download.call_args[0][0]["referencefile_id"] == 801
-            mock_convert.assert_called_once_with(tei_bytes, "tei")
+            assert mock_download.call_args[0][0]["referencefile_id"] == 800
+            mock_convert.assert_not_called()
+            with open(os.path.join(tmp, "AGRKB_1.md"), "rb") as fh:
+                assert fh.read() == b"# md from other mod"
 
 
 @patch("utils.abc_utils.get_authentication_token", return_value="t")

--- a/tests/utils/test_get_documents.py
+++ b/tests/utils/test_get_documents.py
@@ -1,0 +1,35 @@
+"""Tests for get_documents text assembly (section selection).
+
+Keywords/metadata are opt-in and default OFF so the fulltext stays
+byte-identical to what production models were trained on.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from utils import get_documents
+
+
+def _run(tmp, **kwargs):
+    with open(os.path.join(tmp, "AGRKB_101000000000001.md"), "w") as fh:
+        fh.write("# doc")
+    return get_documents.get_documents(tmp, **kwargs)
+
+
+@patch("utils.get_documents.AllianceMarkdown")
+def test_default_excludes_keywords_and_metadata(mock_md_cls):
+    inst = mock_md_cls.return_value
+    inst.get_fulltext.return_value = "body"
+    with tempfile.TemporaryDirectory() as tmp:
+        _run(tmp)
+    inst.get_fulltext.assert_called_once_with(include_keywords=False, include_metadata=False)
+
+
+@patch("utils.get_documents.AllianceMarkdown")
+def test_opt_in_includes_keywords_and_metadata(mock_md_cls):
+    inst = mock_md_cls.return_value
+    inst.get_fulltext.return_value = "body"
+    with tempfile.TemporaryDirectory() as tmp:
+        _run(tmp, include_keywords=True, include_metadata=True)
+    inst.get_fulltext.assert_called_once_with(include_keywords=True, include_metadata=True)

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -900,13 +900,22 @@ def _try_download_main_md(reference_curie: str, output_dir: str, mod_abbreviatio
     base_name = reference_curie.replace(":", "_")
     out_path = os.path.join(output_dir, base_name + ".md")
 
+    md_candidates = [
+        rf for rf in resp_obj
+        if rf.get("file_extension") == "md"
+        and rf.get("file_class") == "converted_merged_main"
+    ]
+    # A converted_merged_main MD is the paper's full text and is MOD-agnostic.
+    # Most are stored globally (mod_id NULL), but the weekly conversion cron
+    # scopes some to a specific MOD. Prefer an MD scoped to this MOD or stored
+    # globally, but fall back to any converted MD so a cron-scoped MD for a
+    # different MOD is still used instead of being reported as "no MD/TEI".
     md_ref_file = next(
-        (rf for rf in resp_obj
-         if rf.get("file_extension") == "md"
-         and rf.get("file_class") == "converted_merged_main"
-         and _reffile_matches_mod(rf, mod_abbreviation)),
+        (rf for rf in md_candidates if _reffile_matches_mod(rf, mod_abbreviation)),
         None,
     )
+    if md_ref_file is None:
+        md_ref_file = md_candidates[0] if md_candidates else None
     if md_ref_file is not None:
         content = get_file_from_abc_reffile_obj(md_ref_file)
         if content:

--- a/utils/date_utils.py
+++ b/utils/date_utils.py
@@ -1,0 +1,62 @@
+"""Robust parsing of free-form (PubMed-style) reference publication dates.
+
+PubMed ``date_published`` values are messy: ISO dates, year-only (``2019``),
+year+month (``2019-03``, ``Mar 2019``, ``2019 Mar``), month ranges
+(``2019 Mar-Apr``), seasons (``Summer 2019``), and more. This module parses
+them to a ``datetime`` for comparison, resolving missing components to the
+earliest instant (year -> Jan 1, year+month -> the 1st).
+"""
+
+import logging
+import re
+from datetime import datetime
+from typing import Optional
+
+from dateutil import parser as _dateutil_parser
+
+logger = logging.getLogger(__name__)
+
+# Plausible publication years (1500-2199); avoids matching stray numbers.
+_YEAR_RE = re.compile(r"\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b")
+# Collapse an alphabetic month range like "Mar-Apr" / "Mar / Apr" to its first
+# month so dateutil reads a single date. Restricted to alpha tokens so it never
+# touches numeric ISO dates ("2019-03-15").
+_MONTH_RANGE_RE = re.compile(r"(?i)\b([a-z]{3,9})\s*[-/]\s*[a-z]{3,9}\b")
+
+
+def parse_reference_date(date_str: Optional[str]) -> Optional[datetime]:
+    """Best-effort parse of a free-form reference date.
+
+    Returns a ``datetime`` (missing components default to the earliest instant),
+    or ``None`` when the input is empty or contains no plausible 4-digit year.
+    """
+    if not date_str:
+        return None
+    s = str(date_str).strip()
+    if not s:
+        return None
+
+    # Fast path: ISO date / datetime ("2019-03-15", "2019-03-15T10:00:00").
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(s[:10], fmt)
+        except ValueError:
+            pass
+    # Year + numeric month ("2019-03").
+    try:
+        return datetime.strptime(s[:7], "%Y-%m")
+    except ValueError:
+        pass
+
+    # Free-form: require a plausible year, then let dateutil read whatever month/
+    # day it can, anchoring missing components to Jan 1 of that year.
+    match = _YEAR_RE.search(s)
+    if not match:
+        return None
+    year = int(match.group(1))
+    cleaned = _MONTH_RANGE_RE.sub(r"\1", s)
+    try:
+        return _dateutil_parser.parse(cleaned, default=datetime(year, 1, 1), fuzzy=True)
+    except (ValueError, OverflowError, TypeError):
+        # Year is known even if the rest is unparseable.
+        return datetime(year, 1, 1)

--- a/utils/embedding.py
+++ b/utils/embedding.py
@@ -25,6 +25,27 @@ BOW_CONFIG = {
 }
 
 
+# Stateless LSH bag-of-concepts configuration (SCRUM-6132 follow-up). Instead of
+# hashing token *strings* (BOW_CONFIG) or fitting k-means concept clusters, we
+# hash each in-vocabulary word's *embedding* with random-hyperplane LSH
+# (Charikar SimHash): similar vectors collide into the same bucket on purpose,
+# so synonyms/near-synonyms land in one bag bin without any clustering. The
+# random projection is a pure function of (seed, n_bits, n_tables, dim), so it
+# is regenerated identically at train and classify time -- nothing is fitted and
+# no artifact is shipped, exactly like the hashing BoW block. ``n_tables``
+# independent projections are concatenated to reduce the chance that a single
+# random hyperplane splits a dense concept region.
+LSH_CONFIG = {
+    "n_bits": 12,      # 2**12 = 4096 buckets per table
+    "n_tables": 4,     # independent projections, concatenated -> 4 * 4096 = 16384 dims
+    "seed": 6132,      # fixed -> reproducible across train/classify, nothing shipped
+}
+
+# Cache the random projection per embedding dimension: it is deterministic, so it
+# only needs to be materialised once per process rather than per document.
+_LSH_PROJECTION_CACHE: dict = {}
+
+
 def load_embedding_model(model_path):
     logger.info("Loading embeddings...")
     if model_path.endswith(".vec.bin"):
@@ -38,6 +59,60 @@ def load_embedding_model(model_path):
 def get_bow_vectorizer():
     """Return a fresh, stateless HashingVectorizer built from BOW_CONFIG."""
     return HashingVectorizer(**BOW_CONFIG)
+
+
+def lsh_feature_width():
+    """Width of the LSH bag-of-concepts block (``n_tables * 2**n_bits``)."""
+    return LSH_CONFIG["n_tables"] * (1 << LSH_CONFIG["n_bits"])
+
+
+def get_lsh_projection(dim):
+    """Return the (cached) random-hyperplane projection for an embedding of size
+    ``dim``: an array of shape ``(n_tables, n_bits, dim)`` drawn from a fixed
+    seed. Deterministic, so train and classify produce identical buckets.
+    """
+    key = (dim, LSH_CONFIG["n_bits"], LSH_CONFIG["n_tables"], LSH_CONFIG["seed"])
+    projection = _LSH_PROJECTION_CACHE.get(key)
+    if projection is None:
+        rng = np.random.default_rng(LSH_CONFIG["seed"])
+        projection = rng.standard_normal((LSH_CONFIG["n_tables"], LSH_CONFIG["n_bits"], dim))
+        _LSH_PROJECTION_CACHE[key] = projection
+    return projection
+
+
+def _raw_embeddings(model, valid_words):
+    """Return the raw (un-preprocessed) embedding matrix for ``valid_words``.
+
+    LSH hashes the model's own word vectors so a given word always falls in the
+    same concept bucket, independent of the document it appears in (per-document
+    standardisation/normalisation would make a word's bucket context-dependent).
+    """
+    if isinstance(model, KeyedVectors):
+        return model[valid_words]
+    return np.array([model.get_word_vector(word) for word in valid_words])
+
+
+def _lsh_histogram(raw_embeddings, dim):
+    """Return a ``(1, lsh_feature_width())`` sparse row: the count of in-vocab
+    words falling in each LSH bucket, across all ``n_tables`` projections.
+
+    Each word's sign pattern under one projection (``sign(R . v)``) packs into an
+    ``n_bits`` integer; that integer (offset by the table) is the bucket index.
+    """
+    projection = get_lsh_projection(dim)
+    n_tables, n_bits, _ = projection.shape
+    bucket_size = 1 << n_bits
+    powers = (1 << np.arange(n_bits))
+    codes = []
+    for table in range(n_tables):
+        projected = raw_embeddings @ projection[table].T          # (n_valid, n_bits)
+        bits = (projected > 0).astype(np.int64)
+        codes.append(bits @ powers + table * bucket_size)         # (n_valid,)
+    codes = np.concatenate(codes)
+    columns, counts = np.unique(codes, return_counts=True)
+    return sp.csr_matrix(
+        (counts.astype(np.float64), columns, np.array([0, len(columns)])),
+        shape=(1, n_tables * bucket_size))
 
 
 def _default_word_to_index(model):
@@ -104,24 +179,29 @@ def get_document_embedding(model, document, weighted_average_word_embedding: boo
 
 
 def build_document_features(model, document, *, use_max_pooling: bool = False, use_bow: bool = False,
-                            weighted_average_word_embedding: bool = False,
+                            use_lsh: bool = False, weighted_average_word_embedding: bool = False,
                             standardize_embeddings: bool = False, normalize_embeddings: bool = False,
                             word_to_index=None, bow_vectorizer=None):
     """Build the classifier feature vector for a single document.
 
-    The optional blocks are concatenated in a fixed order ``[mean | max? | bow?]``:
+    The optional blocks are concatenated in a fixed order ``[mean | max? | lsh? | bow?]``:
 
     - ``mean``: the existing mean-pooled embedding (identical to
-      :func:`get_document_embedding`). Always present.
+      :func:`get_document_embedding`). Always present and always first (the
+      classify "valid embedding" gate slices it off the front).
     - ``max`` (``use_max_pooling``): element-wise max over the valid word vectors,
       capturing the strongest activation any token produces — the signal mean
       pooling averages away.
+    - ``lsh`` (``use_lsh``): a stateless LSH bag-of-concepts block (see
+      :data:`LSH_CONFIG`) — random-hyperplane buckets over the word embeddings,
+      so near-synonyms share a bin. Captures concept presence; unlike ``bow`` it
+      can only bin words that have an embedding (OOV identifiers have no vector).
     - ``bow`` (``use_bow``): a stateless hashing bag-of-words block (see
       :data:`BOW_CONFIG`) capturing the presence of discriminative tokens,
       including identifiers that are out-of-vocabulary for the embedding.
 
-    Returns a dense ``np.ndarray`` when ``use_bow`` is False, otherwise a sparse
-    ``scipy.sparse`` row (because the BoW block is high-dimensional and sparse).
+    Returns a dense ``np.ndarray`` when no sparse block is requested, otherwise a
+    sparse ``scipy.sparse`` row (the ``lsh``/``bow`` blocks are high-dimensional).
     """
     embeddings_2d, valid_words, dim = _valid_word_embeddings(
         model, document, standardize_embeddings=standardize_embeddings,
@@ -140,35 +220,43 @@ def build_document_features(model, document, *, use_max_pooling: bool = False, u
         blocks.append(max_block)
     dense = np.concatenate(blocks)
 
-    if not use_bow:
-        return dense
+    sparse_blocks = []
+    if use_lsh:
+        if valid_words:
+            sparse_blocks.append(_lsh_histogram(_raw_embeddings(model, valid_words), dim))
+        else:
+            sparse_blocks.append(sp.csr_matrix((1, lsh_feature_width())))
+    if use_bow:
+        if bow_vectorizer is None:
+            bow_vectorizer = get_bow_vectorizer()
+        sparse_blocks.append(bow_vectorizer.transform([document]))
 
-    if bow_vectorizer is None:
-        bow_vectorizer = get_bow_vectorizer()
-    bow_block = bow_vectorizer.transform([document])
-    return sp.hstack([sp.csr_matrix(dense.reshape(1, -1)), bow_block], format="csr")
+    if not sparse_blocks:
+        return dense
+    return sp.hstack([sp.csr_matrix(dense.reshape(1, -1)), *sparse_blocks], format="csr")
 
 
 def build_feature_matrix(model, documents, *, use_max_pooling: bool = False, use_bow: bool = False,
-                         weighted_average_word_embedding: bool = False,
+                         use_lsh: bool = False, weighted_average_word_embedding: bool = False,
                          standardize_embeddings: bool = False, normalize_embeddings: bool = False,
                          word_to_index=None):
     """Build the stacked feature matrix ``X`` for a list of documents.
 
-    Returns a dense ``np.ndarray`` (``use_bow`` False) or a sparse CSR matrix
-    (``use_bow`` True). A single BoW vectorizer is shared across the batch.
+    Returns a dense ``np.ndarray`` when no sparse block is requested, or a sparse
+    CSR matrix when ``use_bow``/``use_lsh`` is set. A single BoW vectorizer is
+    shared across the batch.
     """
     if word_to_index is None:
         word_to_index = _default_word_to_index(model)
     bow_vectorizer = get_bow_vectorizer() if use_bow else None
     rows = [
         build_document_features(
-            model, document, use_max_pooling=use_max_pooling, use_bow=use_bow,
+            model, document, use_max_pooling=use_max_pooling, use_bow=use_bow, use_lsh=use_lsh,
             weighted_average_word_embedding=weighted_average_word_embedding,
             standardize_embeddings=standardize_embeddings, normalize_embeddings=normalize_embeddings,
             word_to_index=word_to_index, bow_vectorizer=bow_vectorizer)
         for document in documents
     ]
-    if use_bow:
+    if use_bow or use_lsh:
         return sp.vstack(rows, format="csr")
     return np.vstack(rows)

--- a/utils/embedding.py
+++ b/utils/embedding.py
@@ -2,10 +2,27 @@ import logging
 
 import fasttext
 import numpy as np
+import scipy.sparse as sp
 from gensim.models import KeyedVectors
+from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.preprocessing import StandardScaler
 
 logger = logging.getLogger(__name__)
+
+
+# Stateless bag-of-words configuration (SCRUM-6132). A HashingVectorizer built
+# from these constants needs no fitting, no vocabulary and no IDF, so the train
+# and classify scripts produce identical features without shipping any artifact.
+# Keep this in one place: it is the single source of truth both scripts share.
+BOW_CONFIG = {
+    "n_features": 2 ** 18,
+    "ngram_range": (1, 1),
+    "alternate_sign": False,
+    "norm": "l2",
+    "binary": False,
+    "lowercase": True,
+    "token_pattern": r"(?u)\b[\w-]{2,}\b",
+}
 
 
 def load_embedding_model(model_path):
@@ -18,47 +35,140 @@ def load_embedding_model(model_path):
     return model
 
 
-def get_document_embedding(model, document, weighted_average_word_embedding: bool = False,
-                           standardize_embeddings: bool = False, normalize_embeddings: bool = False,
-                           word_to_index=None):
-    # Split the document into words
+def get_bow_vectorizer():
+    """Return a fresh, stateless HashingVectorizer built from BOW_CONFIG."""
+    return HashingVectorizer(**BOW_CONFIG)
+
+
+def _default_word_to_index(model):
+    if isinstance(model, KeyedVectors):
+        return model.key_to_index
+    return {word: idx for idx, word in enumerate(model.get_words())}
+
+
+def _valid_word_embeddings(model, document, standardize_embeddings: bool = False,
+                           normalize_embeddings: bool = False):
+    """Return (embeddings_2d, valid_words, dim) for the in-vocabulary words of
+    ``document``, with the same preprocessing the classifier has always used.
+
+    ``embeddings_2d`` is ``None`` when the document has no in-vocabulary words.
+    """
     words = document.split()
     if isinstance(model, KeyedVectors):
+        dim = model.vector_size
         vocab = set(model.key_to_index.keys())
         valid_words = [word for word in words if word in vocab]
         if not valid_words:
-            return np.zeros(model.vector_size)
+            return None, [], dim
         embeddings = model[valid_words]
-        if word_to_index is None:
-            word_to_index = model.key_to_index
     else:
+        dim = model.get_dimension()
         vocab = set(model.get_words())
         valid_words = [word for word in words if word in vocab]
         if not valid_words:
-            return np.zeros(model.get_dimension())
+            return None, [], dim
         embeddings = np.array([model.get_word_vector(word) for word in valid_words])
-        if word_to_index is None:
-            word_to_index = {word: idx for idx, word in enumerate(model.get_words())}
 
     if embeddings.size == 0:
-        return np.zeros(model.get_dimension())
+        return None, [], dim
 
-    epsilon = 1e-10
     embeddings_2d = embeddings
-
     if standardize_embeddings:
-        # Standardize the embeddings
         scaler = StandardScaler()
         embeddings_2d = scaler.fit_transform(embeddings_2d)
-
     if normalize_embeddings:
-        # Normalize the embeddings
+        epsilon = 1e-10
         norm = np.linalg.norm(embeddings_2d, axis=1, keepdims=True) + epsilon
-        embeddings_2d /= norm
+        embeddings_2d = embeddings_2d / norm
+    return embeddings_2d, valid_words, dim
 
+
+def _pool_mean(embeddings_2d, valid_words, weighted_average_word_embedding, word_to_index):
     if weighted_average_word_embedding:
         weights = np.array([word_to_index[word] / len(word_to_index) for word in valid_words])
-        doc_embedding = np.average(embeddings_2d, axis=0, weights=weights)
+        return np.average(embeddings_2d, axis=0, weights=weights)
+    return np.mean(embeddings_2d, axis=0)
+
+
+def get_document_embedding(model, document, weighted_average_word_embedding: bool = False,
+                           standardize_embeddings: bool = False, normalize_embeddings: bool = False,
+                           word_to_index=None):
+    embeddings_2d, valid_words, dim = _valid_word_embeddings(
+        model, document, standardize_embeddings=standardize_embeddings,
+        normalize_embeddings=normalize_embeddings)
+    if embeddings_2d is None:
+        return np.zeros(dim)
+    if word_to_index is None:
+        word_to_index = _default_word_to_index(model)
+    return _pool_mean(embeddings_2d, valid_words, weighted_average_word_embedding, word_to_index)
+
+
+def build_document_features(model, document, *, use_max_pooling: bool = False, use_bow: bool = False,
+                            weighted_average_word_embedding: bool = False,
+                            standardize_embeddings: bool = False, normalize_embeddings: bool = False,
+                            word_to_index=None, bow_vectorizer=None):
+    """Build the classifier feature vector for a single document.
+
+    The optional blocks are concatenated in a fixed order ``[mean | max? | bow?]``:
+
+    - ``mean``: the existing mean-pooled embedding (identical to
+      :func:`get_document_embedding`). Always present.
+    - ``max`` (``use_max_pooling``): element-wise max over the valid word vectors,
+      capturing the strongest activation any token produces — the signal mean
+      pooling averages away.
+    - ``bow`` (``use_bow``): a stateless hashing bag-of-words block (see
+      :data:`BOW_CONFIG`) capturing the presence of discriminative tokens,
+      including identifiers that are out-of-vocabulary for the embedding.
+
+    Returns a dense ``np.ndarray`` when ``use_bow`` is False, otherwise a sparse
+    ``scipy.sparse`` row (because the BoW block is high-dimensional and sparse).
+    """
+    embeddings_2d, valid_words, dim = _valid_word_embeddings(
+        model, document, standardize_embeddings=standardize_embeddings,
+        normalize_embeddings=normalize_embeddings)
+    if word_to_index is None:
+        word_to_index = _default_word_to_index(model)
+
+    if embeddings_2d is None:
+        mean_block = np.zeros(dim)
     else:
-        doc_embedding = np.mean(embeddings_2d, axis=0)
-    return doc_embedding
+        mean_block = _pool_mean(embeddings_2d, valid_words, weighted_average_word_embedding, word_to_index)
+
+    blocks = [mean_block]
+    if use_max_pooling:
+        max_block = np.zeros(dim) if embeddings_2d is None else embeddings_2d.max(axis=0)
+        blocks.append(max_block)
+    dense = np.concatenate(blocks)
+
+    if not use_bow:
+        return dense
+
+    if bow_vectorizer is None:
+        bow_vectorizer = get_bow_vectorizer()
+    bow_block = bow_vectorizer.transform([document])
+    return sp.hstack([sp.csr_matrix(dense.reshape(1, -1)), bow_block], format="csr")
+
+
+def build_feature_matrix(model, documents, *, use_max_pooling: bool = False, use_bow: bool = False,
+                         weighted_average_word_embedding: bool = False,
+                         standardize_embeddings: bool = False, normalize_embeddings: bool = False,
+                         word_to_index=None):
+    """Build the stacked feature matrix ``X`` for a list of documents.
+
+    Returns a dense ``np.ndarray`` (``use_bow`` False) or a sparse CSR matrix
+    (``use_bow`` True). A single BoW vectorizer is shared across the batch.
+    """
+    if word_to_index is None:
+        word_to_index = _default_word_to_index(model)
+    bow_vectorizer = get_bow_vectorizer() if use_bow else None
+    rows = [
+        build_document_features(
+            model, document, use_max_pooling=use_max_pooling, use_bow=use_bow,
+            weighted_average_word_embedding=weighted_average_word_embedding,
+            standardize_embeddings=standardize_embeddings, normalize_embeddings=normalize_embeddings,
+            word_to_index=word_to_index, bow_vectorizer=bow_vectorizer)
+        for document in documents
+    ]
+    if use_bow:
+        return sp.vstack(rows, format="csr")
+    return np.vstack(rows)

--- a/utils/get_documents.py
+++ b/utils/get_documents.py
@@ -17,7 +17,8 @@ nltk.download('punkt_tab')
 logger = logging.getLogger(__name__)
 
 
-def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
+def get_documents(input_docs_dir: str, include_keywords: bool = False,
+                  include_metadata: bool = False) -> List[Tuple[str, str, str, str]]:
     """Load every parseable Markdown document in ``input_docs_dir`` as
     ``(file_path, fulltext, title, abstract)``.
 
@@ -27,6 +28,12 @@ def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
     conversion, and (optionally) requests on-demand server-side conversion
     via the ``/reference/referencefile/conversion_request`` endpoint when
     no MD or TEI is yet available in ABC.
+
+    ``include_keywords`` / ``include_metadata`` add author keywords and article
+    metadata to the fulltext. Both default to ``False`` so the text is
+    byte-identical to what models currently in production were trained on; new
+    models opt in by passing the matching flags at BOTH train and classify time
+    (references stay excluded regardless).
     """
     documents: List[Tuple[str, str, str, str]] = []
     for file_path in glob.glob(os.path.join(input_docs_dir, "*")):
@@ -40,7 +47,9 @@ def get_documents(input_docs_dir: str) -> List[Tuple[str, str, str, str]]:
         try:
             md = AllianceMarkdown()
             md.load_from_file(file_path)
-            documents.append((file_path, md.get_fulltext(), md.get_title(), md.get_abstract()))
+            fulltext = md.get_fulltext(include_keywords=include_keywords,
+                                       include_metadata=include_metadata)
+            documents.append((file_path, fulltext, md.get_title(), md.get_abstract()))
         except Exception as e:
             logger.warning(f"Failed to parse Markdown {file_path}: {e}")
     return documents


### PR DESCRIPTION
## SCRUM-6132 — Improve classifiers by adding BoW/TFIDF

Adds three **independent, stateless, opt-in** feature blocks to the document classifier, all passed identically at train and classify time and shared through one builder in `utils/embedding.py` (block order `[mean | max? | lsh? | bow?]`; nothing fitted, nothing shipped — the owner manages train/classify parity):

- **`--use_bow_features`** — stateless hashing bag-of-words (`HashingVectorizer`, no IDF, no fit).
- **`--use_max_pooling`** — element-wise max pooling alongside the existing mean.
- **`--use_lsh_features`** — LSH bag-of-concepts (random-hyperplane SimHash over the word embeddings, so near-synonyms share a bucket); projection is a pure function of a fixed seed, regenerated identically at train/classify.

Also: LinearSVC + LGBMClassifier added to the model zoo; SVC/MLP skipped on the high-dim sparse BoW matrix (OOM/weak); sparse `X` handled throughout.

### Experimental outcome (WB catalytic activity + FB new transgenic construct)
- **BoW is the win** and the production choice — FB 0.76→0.92 held-out, WB 0.80→0.86.
- **Max-pooling**: no meaningful effect.
- **LSH bag-of-concepts**: works as a concept feature (big lift over mean embeddings, ties BoW on WB) but is **redundant** with token BoW — combining never beats BoW alone, and it trails BoW on identifier-heavy FB (OOV IDs have no embedding to hash). Kept as opt-in, off by default.
- **Keywords/metadata** (`--include_keywords` / `--include_metadata`): not useful; **metadata overfits** (WB CV 0.85 → held-out 0.81). Left off.

### Also on this branch (training-data fixes, kept here per request)
- MOD-agnostic selection of `converted_merged_main` MDs + no on-demand conversion when building training sets (`ff88857`).
- Robust PubMed date parsing for `--filter_date_before` (`239b44e`).

### Verification
- `tests/utils/test_classifier_features.py` — 12 tests, all pass (mean-only path byte-for-byte unchanged).
- flake8 clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)