### PR TITLE
remove deprecated grobid PDF2TEI conversion path

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,6 @@ TRAINING_DIR=/data/agr_document_classifier/training
 CLASSIFICATION_DIR=/data/agr_document_classifier/to_classify
 CLASSIFIERS_PATH=/data/agr_document_classifier
 
-GROBID_API_URL=https://grobid.alliancegenome.org/api
 ABC_API_SERVER=literature-rest.alliancegenome.org
 CURATION_API_SERVER=https://curation.alliancegenome.org/api/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,6 @@ Key environment variables (set in `.env`):
 - `OKTA_*`: OAuth2 authentication credentials
 - `TRAINING_DIR`, `CLASSIFICATION_DIR`: Data directories
 - `CLASSIFIERS_PATH`: Model storage location
-- `GROBID_API_URL`: PDF-to-TEI conversion service
 
 ### Pipeline Workflow
 1. Training: Downloads TEI documents → Extracts text → Generates embeddings → Trains classifier → Uploads model to ABC

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The project uses environment variables for configuration. These variables are de
 - TRAINING_DIR: Directory for training data.
 - CLASSIFICATION_DIR: Directory for documents to classify.
 - CLASSIFIERS_PATH: Path to save classifiers.
-- GROBID_API_URL: URL for the GROBID API.
 - ABC_API_SERVER: URL for the ABC API server.
 - OKTA_*: Configuration for Okta authentication.
 - CLASSIFICATION_BATCH_SIZE: Batch size for document classification.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
       - ${AGR_CORPUS_DOWNLOAD_DIR}:${AGR_CORPUS_DOWNLOAD_DIR}
       - ${ENTITY_EXTRACTION_PATH}:/data/agr_entity_extraction
     environment:
-      - GROBID_API_URL=${GROBID_API_URL}
       - TMP_PATH=${TMP_PATH}
       - ABC_API_SERVER=${ABC_API_SERVER}
       - OKTA_CLIENT_ID=${OKTA_CLIENT_ID}

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -886,14 +886,6 @@ def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abb
             out_file.write(supp_bytes)
 
 
-def convert_pdf_with_grobid(file_content):
-    grobid_api_url = os.environ.get("GROBID_API_URL",
-                                    "https://grobid.alliancegenome.org/api/processFulltextDocument")
-    # Send the file content to the GROBID API
-    response = requests.post(grobid_api_url, files={'input': ("file", file_content)})
-    return response
-
-
 def get_model_data(mod_abbreviation: str, task_type: str, topic: str):
     model_data = None
     get_model_url = f"{blue_api_base_url}/ml_model/metadata/{task_type}/{mod_abbreviation}/{topic}"


### PR DESCRIPTION
Remove the unused convert_pdf_with_grobid() helper and its grobid endpoint config. The local PDF->TEI->MD path was replaced by ABC and the function had no remaining callers.

- Remove convert_pdf_with_grobid() from utils/abc_utils.py
- Remove GROBID_API_URL (grobid.alliancegenome.org) from .env