### PR TITLE
SCRUM-6132: prevent OOM on BoW classifier training (+ dataset-version fallback)

### DIFF
--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -199,6 +199,19 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
         # Reduce n_iter for faster training with focus on regularization
         n_iter = 50 if classifier_name in ['LogisticRegression', 'SGDClassifier'] else 30
 
+        # RandomizedSearchCV fans every candidate fit out to its own worker
+        # process. On the wide sparse BoW/LSH matrix (2**18 columns) an XGBoost
+        # worker allocates gradient-histogram buffers sized by n_features
+        # (~3 GB per fit), so the default n_jobs=-1 (one worker per core) peaked
+        # at ~51 GB on the largest dataset and systemd-oomd killed the whole user
+        # slice. Cap XGBoost's *search* concurrency on wide matrices; the lighter
+        # models materialise far less and ran fine at full width. n_jobs does not
+        # change the result (the search is deterministic given random_state), so
+        # model-selection stats are unaffected. Override with SEARCH_MAX_JOBS.
+        search_n_jobs = -1
+        if (use_bow_features or use_lsh_features) and classifier_name == 'XGBClassifier':
+            search_n_jobs = int(os.environ.get('SEARCH_MAX_JOBS', '4'))
+
         random_search = RandomizedSearchCV(
             estimator=classifier_info['model'],
             n_iter=n_iter,
@@ -207,7 +220,7 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
             scoring=scoring,
             refit='f1',
             verbose=1,
-            n_jobs=-1,
+            n_jobs=search_n_jobs,
             random_state=42
         )
         random_search.fit(X_train_val, y_train_val)

--- a/agr_document_classifier/models.py
+++ b/agr_document_classifier/models.py
@@ -95,7 +95,12 @@ POSSIBLE_CLASSIFIERS = {
         }
     },
     'XGBClassifier': {
-        'model': XGBClassifier(random_state=42, eval_metric='logloss'),
+        # n_jobs=1: XGBoost otherwise grabs every core, and under the parallel
+        # RandomizedSearchCV (n_jobs=-1) that becomes workers x cores threads,
+        # each allocating per-thread buffers sized by the wide BoW feature matrix
+        # (2**18 cols) -> OOM. RF/GBM/LGBM default to single-threaded, so only XGB
+        # oversubscribed. Let the outer search own the parallelism.
+        'model': XGBClassifier(random_state=42, eval_metric='logloss', n_jobs=1),
         'params': {
             'n_estimators': randint(50, 150),  # Reduced iterations
             'learning_rate': loguniform(0.01, 0.3),  # Lower learning rates

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -1181,13 +1181,26 @@ def set_indexing_priority(ref_curie, mod_abbr, priority_name, confidence_score):
 
 def get_training_set_from_abc(mod_abbreviation: str, topic: str, metadata_only: bool = False, version: int = None):
     endpoint = "metadata" if metadata_only else "download"
-    if version:
-        url = f"{blue_api_base_url}/datasets/{endpoint}/{mod_abbreviation}/{topic}/document/{version}/"
-    else:
-        url = f"{blue_api_base_url}/datasets/{endpoint}/{mod_abbreviation}/{topic}/document/"
+
+    def _dataset_url(ver):
+        if ver:
+            return f"{blue_api_base_url}/datasets/{endpoint}/{mod_abbreviation}/{topic}/document/{ver}/"
+        return f"{blue_api_base_url}/datasets/{endpoint}/{mod_abbreviation}/{topic}/document/"
+
     token = get_authentication_token()
     headers = generate_headers(token)
-    response = requests.get(url, headers=headers)
+    response = requests.get(_dataset_url(version), headers=headers)
+
+    # A specific dataset version may not exist for every MOD/topic (e.g. FB
+    # topics only have version 1, while WB has version 2). Rather than hard-fail
+    # on a 404, fall back to the latest available version so a mixed-MOD sweep
+    # that pins a single --dataset_version can still proceed.
+    if response.status_code == 404 and version:
+        logger.warning(f"Dataset {endpoint} version {version} not found for "
+                       f"{mod_abbreviation}/{topic}; falling back to the latest available version.")
+        version = None
+        response = requests.get(_dataset_url(version), headers=headers)
+
     if response.status_code == 200:
         dataset = response.json()
         if version:


### PR DESCRIPTION
## Summary
Training a BoW-features document classifier across all WB+FB production topics kept getting killed mid-run. Root cause and fixes below.

### 1. OOM during model selection (main fix — `8840a2d`)
`RandomizedSearchCV(n_jobs=-1)` runs one worker process per core (16 here). On the wide sparse BoW matrix (2\*\*18 columns) each XGBoost fit allocates gradient-histogram buffers sized by `n_features` (~3 GB/fit), so 16 concurrent XGB fits peaked at ~51 GB on the largest dataset (WB ATP:0000041, ~7,100 docs) and `systemd-oomd` killed the entire user slice. The earlier `n_jobs=1` on the XGBClassifier *estimator* (`1bd4bba`) only limited threads per fit, not the number of concurrent fits.

**Fix:** cap XGBoost's *search* concurrency on wide BoW/LSH matrices (`SEARCH_MAX_JOBS`, default 4). Deterministic-safe — `n_jobs` does not change `RandomizedSearchCV` results given `random_state`, so model-selection stats are unchanged. Lighter models keep `n_jobs=-1`.

### 2. Missing dataset version for FB topics (`8f45284`)
`get_training_set_from_abc` hard-failed with a 404 when the pinned `--dataset_version` did not exist for a MOD/topic (FB topics only have v1; WB has v2). Now falls back to the latest available version (logging a warning) so a mixed-MOD sweep pinning a single version can proceed.

## Commits
- `1bd4bba` pin XGBClassifier `n_jobs=1` (initial attempt — necessary but not sufficient)
- `8840a2d` cap XGBoost search concurrency on wide BoW matrices (the actual OOM fix)
- `8f45284` dataset-version 404 → latest fallback

## Validation
Ran a full 16-topic WB+FB sweep end-to-end (both with and without outlier removal): all 16 models trained, **zero OOMs, zero failures**; memory peaked ~40 GB under a 52 GB cap. The 5 FB topics that previously 404'd trained successfully via the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
