### PR TITLE
fix(deps): CPU-only torch to shrink image and fix build disk overflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# CPU-only torch wheels (no CUDA): the +cpu build of torch lives on this index, not PyPI.
+# This removes the multi-GB nvidia-*-cu12 wheels torch would otherwise pull in. The code
+# runs inference on CPU only (HF pipeline uses device=-1; no .cuda() anywhere).
+--extra-index-url https://download.pytorch.org/whl/cpu
 agr_literature_service @ git+https://github.com/alliance-genome/agr_literature_service
 annotated-types==0.7.0
 anyio==3.7.1
@@ -33,18 +37,6 @@ mpmath==1.3.0
 networkx==3.4.2
 nltk>=3.9
 numpy==1.26.4
-nvidia-cublas-cu11==11.10.3.66
-nvidia-cuda-cupti-cu11==11.7.101
-nvidia-cuda-nvrtc-cu11==11.7.99
-nvidia-cuda-runtime-cu11==11.7.99
-nvidia-cudnn-cu11==8.5.0.96
-nvidia-cufft-cu11==10.9.0.58
-nvidia-curand-cu11==10.2.10.91
-nvidia-cusolver-cu11==11.4.0.1
-nvidia-cusparse-cu11==11.7.4.91
-nvidia-nccl-cu11
-nvidia-nccl-cu12
-nvidia-nvtx-cu11==11.7.91
 packaging==24.2
 pluggy==1.5.0
 pyasn1==0.4.8
@@ -72,10 +64,9 @@ sympy==1.13.1
 sqlalchemy==2.0.7
 threadpoolctl==3.5.0
 tokenizers
-torch==2.6.0
+torch==2.6.0+cpu
 tqdm==4.66.4
 transformers==4.48.0
-triton
 typing_extensions==4.12.2
 urllib3==2.3.0
 wrapt==1.16.0


### PR DESCRIPTION
## Problem

The GoCD `docker build` for `agr_document_classifier` started failing with:

```
failed to get digest sha256:...: open /var/lib/docker/image/overlay2/imagedb/content/sha256/...: no such file or directory
```

This is a **Docker daemon disk-write error**, not a code/dependency error — every build step (including `pip install` and the nltk download) succeeded first.

### Root cause

Commit `dd11d76` bumped `torch 2.2.2 → 2.6.0` (RCE patch). The failing command is the **app-only** build (`FROM agr_document_classifier_base`), and the base image was **stale** (still torch 2.2.2). So the app layer uninstalled and reinstalled the entire torch + CUDA `cu12` stack (~2.5–3 GB) into a *new* overlay layer. overlay2 doesn't reclaim the old copies underneath, so the on-disk footprint roughly doubled and overflowed `/var/lib/docker` on the build agent.

## Fix

The codebase never uses a GPU (`bert_entity_extraction/gene_finding/deep_learning.py:42` runs the HF pipeline with `device=-1`; no `.cuda()` anywhere), so the CUDA wheels are dead weight. In `requirements.txt`:

- Added `--extra-index-url https://download.pytorch.org/whl/cpu`
- `torch==2.6.0` → `torch==2.6.0+cpu`
- Removed all 13 `nvidia-*-cu11`/`cu12` lines and `triton`

torch stays pinned at **2.6.0** to keep the `torch.load` RCE patch (GHSA-53q9-r3pm-6pq6).

## Verification (clean local full build)

| Check | Before | After |
|---|---|---|
| torch wheel | 766 MB (CUDA) | **95.7 MB** (`+cpu`) |
| nvidia/triton wheels pulled | many (~2.5 GB) | **0** |
| App image size | ~7 GB | **3.96 GB** |
| App-layer torch install (fresh base) | re-downloads everything | **"Requirement already satisfied"** |
| Digest/disk errors | yes | **none** |

## Operational follow-ups (not in this PR)

- On the GoCD build agent: `docker system prune -af --volumes` to reclaim the overflowed disk.
- Have the pipeline rebuild the **base** image whenever `requirements.txt` changes (`make doc_classifier_full_build`), not the app-only build against a staler base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)