### PR TITLE
fix(abc_utils): return None on HTTP errors and add request timeout

### DIFF
--- a/tests/utils/test_get_file_from_abc_reffile_obj.py
+++ b/tests/utils/test_get_file_from_abc_reffile_obj.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from utils import abc_utils
+
+
+@patch("utils.abc_utils.generate_headers", return_value={})
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.requests.get")
+def test_returns_content_on_200(mock_get, _tok, _hdr):
+    resp = MagicMock()
+    resp.content = b"# real markdown"
+    resp.raise_for_status.return_value = None
+    mock_get.return_value = resp
+
+    out = abc_utils.get_file_from_abc_reffile_obj({"referencefile_id": 1})
+
+    assert out == b"# real markdown"
+    # A request timeout must be honoured so a hung backend cannot block a batch.
+    assert mock_get.call_args.kwargs["timeout"] == 60
+
+
+@patch("utils.abc_utils.generate_headers", return_value={})
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.requests.get")
+def test_returns_none_on_http_error(mock_get, _tok, _hdr):
+    # A 4xx/5xx error body must NOT be returned as document content.
+    resp = MagicMock()
+    resp.content = b'{"detail":"Not Found"}'
+    resp.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+    mock_get.return_value = resp
+
+    assert abc_utils.get_file_from_abc_reffile_obj({"referencefile_id": 1}) is None
+
+
+@patch("utils.abc_utils.generate_headers", return_value={})
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.requests.get")
+def test_returns_none_on_timeout(mock_get, _tok, _hdr):
+    mock_get.side_effect = requests.exceptions.Timeout("timed out")
+
+    assert abc_utils.get_file_from_abc_reffile_obj({"referencefile_id": 1}) is None
+
+
+@patch("utils.abc_utils.generate_headers", return_value={})
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.requests.get")
+def test_returns_none_on_connection_error(mock_get, _tok, _hdr):
+    mock_get.side_effect = requests.exceptions.ConnectionError("boom")
+
+    assert abc_utils.get_file_from_abc_reffile_obj({"referencefile_id": 1}) is None
+
+
+@patch("utils.abc_utils.get_authentication_token", return_value="t")
+@patch("utils.abc_utils.urllib.request.urlopen")
+@patch("utils.abc_utils.urllib.request.Request")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj", return_value=None)
+def test_download_main_pdf_writes_nothing_when_download_fails(
+    _mock_download, _req, mock_urlopen, _tok,
+):
+    """When the download returns None (e.g. an HTTP error), download_main_pdf
+    must not crash and must not write a bogus .pdf file."""
+    import json
+
+    ref_files = [
+        {
+            "file_class": "main",
+            "file_publication_status": "final",
+            "file_extension": "pdf",
+            "referencefile_id": 1,
+            "referencefile_mods": [{"mod_abbreviation": "WB"}],
+        },
+    ]
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(ref_files).encode("utf-8")
+    mock_urlopen.return_value = cm
+
+    with tempfile.TemporaryDirectory() as tmp:
+        abc_utils.download_main_pdf("AGRKB:1", "WB", "AGRKB_1", tmp)
+        assert os.listdir(tmp) == []

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -521,7 +521,8 @@ def get_file_from_abc_reffile_obj(referencefile_json_obj):
     token = get_authentication_token()
     headers = generate_headers(token)
     try:
-        response = requests.request("GET", file_download_api, headers=headers)
+        response = requests.get(file_download_api, headers=headers, timeout=60)
+        response.raise_for_status()
         return response.content
     except requests.exceptions.RequestException as e:
         logger.error(f"Error occurred for accessing/retrieving data from {file_download_api}: error={e}")
@@ -615,8 +616,11 @@ def download_main_pdf(agr_curie, mod_abbreviation, file_name, output_dir):
                         break
             if main_pdf_ref_file:
                 file_content = get_file_from_abc_reffile_obj(main_pdf_ref_file)
-                with open(os.path.join(output_dir, file_name + ".pdf"), "wb") as out_file:
-                    out_file.write(file_content)
+                if file_content:
+                    with open(os.path.join(output_dir, file_name + ".pdf"), "wb") as out_file:
+                        out_file.write(file_content)
+                else:
+                    logger.error(f"Main PDF download returned no bytes for {agr_curie}")
     except HTTPError as e:
         logger.error(e)
 


### PR DESCRIPTION
## SCRUM-6120

`get_file_from_abc_reffile_obj` had two latent bugs (found while investigating SCRUM-6119):

1. **HTTP error bodies written to disk as document content.** The function returned `response.content` with no status check. On a 4xx/5xx the backend's error body is non-empty bytes, so callers that test `if content:` wrote the error payload to disk as `<curie>.md`/`.tei`/`.pdf` — and that bogus "document" was then fed to the classifier / entity extractor, producing meaningless TET tags in ABC.
2. **No request timeout.** A hung ABC backend could block an entire classification/extraction batch indefinitely.

## Changes

- **`utils/abc_utils.py` — `get_file_from_abc_reffile_obj`:** switched to `requests.get(..., timeout=60)` + `response.raise_for_status()`. `HTTPError` is a `RequestException` subclass, so non-2xx responses are caught by the existing `except` and the function returns `None`. Matches patterns already used elsewhere in this file.
- **`utils/abc_utils.py` — `download_main_pdf`:** added an `if file_content:` guard (the only caller that wrote the result unconditionally) so the new `None` return no longer crashes with `TypeError` or writes a bogus `.pdf`. The other four callers already handled a falsy return.
- **`tests/utils/test_get_file_from_abc_reffile_obj.py`** (new): covers the happy path (and asserts `timeout=60`), HTTP error → `None`, timeout → `None`, connection error → `None`, and a `download_main_pdf` guard test.

## Acceptance criteria

- ✅ Function returns `None` (not error bytes) on any non-2xx response
- ✅ Honours a request timeout instead of hanging
- ✅ Existing callers behave identically on the happy path

## Verification

- pytest: 18 passed (5 new + existing `test_download_md_files.py`)
- flake8: clean (repo config)
- mypy: no new errors introduced (8 pre-existing errors in the file are unrelated and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)