### PR TITLE
fix(classify): make SVC classification and confidence_score consistent [SCRUM-6241]

### DIFF
--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -89,12 +89,38 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
         )
         return files_loaded, np.array([]), [], valid_embeddings
     X = sp.vstack(rows, format="csr") if sparse_features else np.vstack(rows)
-    classifications = classifier_model.predict(X)
+    classifications, confidence_scores = predict_labels_and_confidence(classifier_model, X)
+    return files_loaded, classifications, confidence_scores, valid_embeddings
+
+
+def predict_labels_and_confidence(classifier_model, X):
+    """Predict labels together with a confidence score for the positive class.
+
+    ``confidence_score`` is the probability of the positive class
+    (``classifier_model.classes_[1]``). The label is derived from that score
+    (``score >= 0.5`` -> positive) instead of from ``classifier_model.predict()``
+    so the two can never disagree.
+
+    This matters for ``SVC(probability=True)``: its ``predict()`` uses the sign of
+    the raw SVM margin while ``predict_proba()`` uses a separately fitted
+    Platt-scaling model, and near the decision boundary the two disagree, yielding
+    a positive classification with ``confidence_score < 0.5`` (documented
+    scikit-learn behavior). For every other classifier ``predict()`` already
+    equals ``argmax(predict_proba())``, so deriving the label from the score is a
+    no-op.
+    """
     try:
         confidence_scores = [classes_proba[1] for classes_proba in classifier_model.predict_proba(X)]
     except AttributeError:
-        confidence_scores = [1 / (1 + np.exp(-decision_value)) for decision_value in classifier_model.decision_function(X)]
-    return files_loaded, classifications, confidence_scores, valid_embeddings
+        # Models without predict_proba (e.g. LinearSVC): map the signed margin
+        # through a sigmoid. predict() is sign(decision_function) there, so label
+        # and score are already consistent; we derive both the same way anyway.
+        confidence_scores = [1 / (1 + np.exp(-decision_value))
+                             for decision_value in classifier_model.decision_function(X)]
+    negative_label, positive_label = classifier_model.classes_[0], classifier_model.classes_[1]
+    classifications = np.array([positive_label if score >= 0.5 else negative_label
+                                for score in confidence_scores])
+    return classifications, confidence_scores
 
 
 def parse_arguments():

--- a/tests/agr_document_classifier/test_classify_confidence_consistency.py
+++ b/tests/agr_document_classifier/test_classify_confidence_consistency.py
@@ -1,0 +1,80 @@
+"""Regression tests for SCRUM-6241.
+
+``classify_documents`` used to derive the label from ``predict()`` and the
+confidence from ``predict_proba()`` independently. For ``SVC(probability=True)``
+those two mechanisms can disagree near the decision boundary (``predict()`` uses
+the sign of the raw SVM margin, ``predict_proba()`` uses a separately fitted
+Platt-scaling model), producing a *positive* classification with
+``confidence_score < 0.5`` (documented scikit-learn behavior).
+
+These tests pin the invariant: the label and the confidence score always agree.
+"""
+
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.svm import SVC, LinearSVC
+
+from agr_document_classifier.agr_document_classifier_classify import predict_labels_and_confidence
+
+
+def _overlapping_dataset():
+    """A deliberately overlapping 2-class dataset. With ``random_state=0`` a
+    fitted ``SVC(probability=True)`` produces several samples where the raw
+    ``predict()`` label disagrees with ``predict_proba()`` around 0.5."""
+    return make_classification(
+        n_samples=200, n_features=8, n_informative=4, n_redundant=0,
+        class_sep=0.3, flip_y=0.25, weights=[0.5, 0.5], random_state=0,
+    )
+
+
+def test_svc_label_and_confidence_always_agree():
+    """Acceptance criteria: no positive with score < 0.5, no negative with
+    score >= 0.5, for ``SVC(probability=True)``."""
+    X, y = _overlapping_dataset()
+    model = SVC(probability=True, random_state=42)
+    model.fit(X, y)
+
+    classifications, confidence_scores = predict_labels_and_confidence(model, X)
+
+    assert len(classifications) == len(confidence_scores) == len(X)
+    for label, score in zip(classifications, confidence_scores):
+        if label > 0:
+            assert score >= 0.5, f"positive classification with confidence {score} < 0.5"
+        else:
+            assert score < 0.5, f"negative classification with confidence {score} >= 0.5"
+
+
+def test_helper_resolves_a_real_svc_disagreement():
+    """Guard against a regression to ``predict()``-derived labels: on this fixed
+    dataset the raw ``SVC.predict()`` disagrees with ``predict_proba()`` for at
+    least one sample, and the helper must side with the confidence score."""
+    X, y = _overlapping_dataset()
+    model = SVC(probability=True, random_state=42)
+    model.fit(X, y)
+
+    raw_pred = model.predict(X)
+    proba_positive = model.predict_proba(X)[:, 1]
+    positive_label = model.classes_[1]
+    disagreements = (raw_pred == positive_label) != (proba_positive >= 0.5)
+    assert disagreements.any(), "test fixture no longer reproduces the SVC disagreement"
+
+    classifications, confidence_scores = predict_labels_and_confidence(model, X)
+    for idx in np.flatnonzero(disagreements):
+        # The helper follows the confidence score, not the raw margin sign.
+        expected = positive_label if proba_positive[idx] >= 0.5 else model.classes_[0]
+        assert classifications[idx] == expected
+        assert (classifications[idx] > 0) == (confidence_scores[idx] >= 0.5)
+
+
+def test_linear_svc_decision_function_fallback_is_consistent():
+    """LinearSVC has no ``predict_proba``; the helper falls back to
+    ``decision_function`` -> sigmoid, which is inherently consistent."""
+    X, y = _overlapping_dataset()
+    model = LinearSVC(random_state=42, max_iter=5000)
+    model.fit(X, y)
+
+    classifications, confidence_scores = predict_labels_and_confidence(model, X)
+
+    assert len(classifications) == len(confidence_scores) == len(X)
+    for label, score in zip(classifications, confidence_scores):
+        assert (label > 0) == (score >= 0.5)


### PR DESCRIPTION
## SCRUM-6241

Fixes a bug where the document classifier's predicted label and its confidence score could disagree for `SVC(probability=True)`.

### Problem
`classify_documents` derived the label from `predict()` and the confidence from `predict_proba()` independently. For `SVC(probability=True)`:
- `predict()` uses the **sign of the raw SVM margin**.
- `predict_proba()` uses **Platt scaling** — a separately fitted logistic model.

Near the decision boundary these disagree, so a **positive** classification could carry `confidence_score < 0.5` (and vice versa). Documented scikit-learn behavior; specific to `SVC` (the `LinearSVC` `decision_function → sigmoid` path is internally consistent).

### Fix
Introduce `predict_labels_and_confidence()`, which derives the label from the confidence score (`score >= 0.5` → positive) while keeping the Platt-scaled `predict_proba()` value as the confidence. This makes label and score consistent **by construction**, works for every model type, and fixes SVC models **already stored in ABC without retraining**.

### Acceptance criteria
- ✅ No positive classification with `confidence_score < 0.5`, and no negative with `confidence_score >= 0.5`.
- ✅ Covered by a regression test (`tests/agr_document_classifier/test_classify_confidence_consistency.py`) using a fixed seed that reproducibly triggers the raw SVC `predict()`/`predict_proba()` disagreement.

### Scope notes
- The **priority classifier** (`agr_priority_classifier_balanced.py`) is intentionally **not** changed: it only trains LogisticRegression/RandomForest (where `predict() == argmax(predict_proba())`) and reports the probability of the *predicted* class, so it is already consistent.
- **Backfill of existing inconsistent DB rows is out of scope** (documented on the ticket): all classifications will be deleted and every reference reclassified once the new OpenAI embeddings are ready for a sweep retrain of all topic classifiers, so backfilling now would be throwaway work.

### Testing
- `pytest tests/agr_document_classifier/` → 22 passed
- flake8 clean on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)