### PR TITLE
fix(docker): package antibody string-matching classifier into the image (SCRUM-5601)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ ADD agr_document_classifier/agr_document_classification_pipeline.py .
 ADD agr_document_classifier/agr_document_classifier_classify.py .
 ADD agr_document_classifier/agr_document_classifier_trainer.py .
 ADD agr_document_classifier/agr_priority_classifier_balanced.py .
+# Antibody string-matching classifier (SCRUM-5601): copy as an importable package so
+# `python3 -m agr_document_classifier.agr_antibody_string_matching_classifier` can resolve
+# `from agr_document_classifier.antibody_rules import ...`.
+ADD agr_document_classifier/__init__.py ./agr_document_classifier/__init__.py
+ADD agr_document_classifier/antibody_rules.py ./agr_document_classifier/antibody_rules.py
+ADD agr_document_classifier/agr_antibody_string_matching_classifier.py ./agr_document_classifier/agr_antibody_string_matching_classifier.py
 ADD agr_dataset_manager/dataset_downloader.py .
 ADD agr_dataset_manager/dataset_upload_from_csv.py .
 ADD agr_entity_extractor/agr_entity_extraction_pipeline.py .


### PR DESCRIPTION
## Problem

The WB antibody string-matching classifier (SCRUM-5601) has never run in production. The workflow is fully wired in ABC — 588 WB references sit in `ATP:0000366` (*antibody string matching classification needed*), the transitions and topic mapping exist — but **zero** references have been processed (none in in-progress/complete/failed, and no `abc_string_matching_antibody` TET source exists in prod).

Root cause: the consumer was never deployed. There is now a new GoCD pipeline (`RunAntibodyStringMatchingClassifier`, group `ExternalServerProcessing`, env `ExternalServers`) that runs:

```
python3 -m agr_document_classifier.agr_antibody_string_matching_classifier -l INFO
```

…but that would fail with `ModuleNotFoundError`, because **the `agr_document_classifier` Docker image never included the antibody code**. The Dockerfile was not updated when SCRUM-5601 added `agr_antibody_string_matching_classifier.py` and `antibody_rules.py`.

## Change

Add the two files (plus the existing empty package `__init__.py`) into the image as an importable `agr_document_classifier/` package, so both the module-style entry point and its `from agr_document_classifier.antibody_rules import ...` resolve at runtime.

- **Additive only.** The existing flat `agr_document_classifier_classify.py` / `..._trainer.py` entry points do not import the `agr_document_classifier` package, so they are unaffected.
- `antibody_rules.py` imports only stdlib; the classifier's other imports (`utils.*`, `agr_literature_service.*`) are already present in the image.

## Verification

- Confirmed the three source files exist and the package import graph resolves against what the image already provides.
- Real verification is the image rebuild via the `CreateClassifierImage` GoCD pipeline, after which `RunAntibodyStringMatchingClassifier` can process the 588-reference backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)