### PR TITLE
SCRUM-5781: consume ABC precomputed embeddings in the document classifier

### DIFF
--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -21,7 +21,7 @@ from utils.abc_utils import download_md_files_for_references, send_classificatio
     set_blue_api_base_url, \
     get_cached_mod_id_from_abbreviation, send_manual_indexing_to_abc, create_workflow_tag, \
     get_current_workflow_status, get_reference_embedding
-from utils.abc_embeddings import parse_embedding_marker, ABC_EMBEDDING_DIM
+from utils.abc_embeddings import is_abc_embedding_model, ABC_EMBEDDING_DIM
 from utils.get_documents import get_documents, remove_stopwords
 from utils.embedding import load_embedding_model, build_document_features, get_bow_vectorizer
 
@@ -233,17 +233,16 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
         else:
             raise
 
-    # Retrocompat switch (SCRUM-5781): a model trained on ABC embeddings carries a
-    # marker in its metadata description. When present we fetch ABC embeddings for
-    # it; when absent the model is a legacy BioWordVec one and the on-the-fly text
+    # Retrocompat switch (SCRUM-5781): a model trained on ABC embeddings has the
+    # embedding_* columns populated in its ml_model metadata. When set we fetch ABC
+    # embeddings for it; when absent (legacy BioWordVec model) the on-the-fly text
     # path below runs unchanged.
-    abc_marker = parse_embedding_marker(model_meta_data.get("description"))
-    use_abc_embeddings = abc_marker is not None
-    abc_use_bow = bool(abc_marker and abc_marker.get("bow"))
+    use_abc_embeddings = is_abc_embedding_model(model_meta_data)
+    abc_use_bow = bool(model_meta_data.get("use_bow_features"))
     if use_abc_embeddings:
         logger.info(f"Model for mod: {mod_abbr}, topic: {topic} uses ABC embeddings "
-                    f"(profile {abc_marker['profile_name']} v{abc_marker['version']}, "
-                    f"bow={abc_use_bow}).")
+                    f"(profile {model_meta_data.get('embedding_profile')} "
+                    f"v{model_meta_data.get('embedding_version')}, bow={abc_use_bow}).")
 
     classification_batch_size = int(os.environ.get("CLASSIFICATION_BATCH_SIZE", 1000))
     jobs_to_process = copy.deepcopy(jobs)

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -238,11 +238,13 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
     # embeddings for it; when absent (legacy BioWordVec model) the on-the-fly text
     # path below runs unchanged.
     use_abc_embeddings = is_abc_embedding_model(model_meta_data)
-    abc_use_bow = bool(model_meta_data.get("use_bow_features"))
+    # Pooling (L2 chunk-mean) and the BoW block are fixed conventions applied to
+    # every ABC-embedding model, so they are not stored on the model — always on.
+    abc_use_bow = True
     if use_abc_embeddings:
         logger.info(f"Model for mod: {mod_abbr}, topic: {topic} uses ABC embeddings "
                     f"(profile {model_meta_data.get('embedding_profile')} "
-                    f"v{model_meta_data.get('embedding_version')}, bow={abc_use_bow}).")
+                    f"v{model_meta_data.get('embedding_version')}).")
 
     classification_batch_size = int(os.environ.get("CLASSIFICATION_BATCH_SIZE", 1000))
     jobs_to_process = copy.deepcopy(jobs)

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -20,7 +20,8 @@ from utils.abc_utils import download_md_files_for_references, send_classificatio
     download_abc_model, set_job_failure, load_all_jobs, get_model_data, \
     set_blue_api_base_url, \
     get_cached_mod_id_from_abbreviation, send_manual_indexing_to_abc, create_workflow_tag, \
-    get_current_workflow_status
+    get_current_workflow_status, get_reference_embedding
+from utils.abc_embeddings import parse_embedding_marker, ABC_EMBEDDING_DIM
 from utils.get_documents import get_documents, remove_stopwords
 from utils.embedding import load_embedding_model, build_document_features, get_bow_vectorizer
 
@@ -92,6 +93,37 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
     X = sp.vstack(rows, format="csr") if sparse_features else np.vstack(rows)
     classifications, confidence_scores = predict_labels_and_confidence(classifier_model, X)
     return files_loaded, classifications, confidence_scores, valid_embeddings
+
+
+def classify_documents_from_abc_embeddings(reference_curies, mod_abbr, classifier_model):
+    """Classify references using the ABC precomputed embeddings (SCRUM-5781).
+
+    The per-reference feature is the mean of the main-PDF paragraph embeddings
+    (:func:`utils.abc_utils.get_reference_embedding`). Returns the same 4-tuple
+    shape as :func:`classify_documents` — ``(ids_loaded, classifications,
+    confidence_scores, valid_embeddings)`` — but ``ids_loaded`` holds reference
+    curies rather than file paths (downstream recovers the curie from either).
+
+    A reference with no available embedding is kept as a zero row flagged invalid,
+    so the caller fails that job just like a missing MD in the BioWordVec path.
+    """
+    rows = []
+    ids_loaded = []
+    valid_embeddings = []
+    for reference_curie in reference_curies:
+        vector = get_reference_embedding(reference_curie, mod_abbr)
+        ids_loaded.append(reference_curie)
+        if vector is None:
+            rows.append(np.zeros(ABC_EMBEDDING_DIM, dtype=np.float32))
+            valid_embeddings.append(False)
+        else:
+            rows.append(vector)
+            valid_embeddings.append(True)
+    if not ids_loaded:
+        return ids_loaded, np.array([]), [], valid_embeddings
+    X = np.vstack(rows)
+    classifications, confidence_scores = predict_labels_and_confidence(classifier_model, X)
+    return ids_loaded, classifications, confidence_scores, valid_embeddings
 
 
 def predict_labels_and_confidence(classifier_model, X):
@@ -192,6 +224,16 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
         else:
             raise
 
+    # Retrocompat switch (SCRUM-5781): a model trained on ABC embeddings carries a
+    # marker in its metadata description. When present we fetch ABC embeddings for
+    # it; when absent the model is a legacy BioWordVec one and the on-the-fly text
+    # path below runs unchanged.
+    abc_marker = parse_embedding_marker(model_meta_data.get("description"))
+    use_abc_embeddings = abc_marker is not None
+    if use_abc_embeddings:
+        logger.info(f"Model for mod: {mod_abbr}, topic: {topic} uses ABC embeddings "
+                    f"(profile {abc_marker['profile_name']} v{abc_marker['version']}).")
+
     classification_batch_size = int(os.environ.get("CLASSIFICATION_BATCH_SIZE", 1000))
     jobs_to_process = copy.deepcopy(jobs)
     classifier_model = joblib.load(classifier_file_path)
@@ -206,43 +248,52 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
         process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
                           test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling,
                           use_lsh_features=use_lsh_features,
-                          include_keywords=include_keywords, include_metadata=include_metadata)
+                          include_keywords=include_keywords, include_metadata=include_metadata,
+                          use_abc_embeddings=use_abc_embeddings)
 
 
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
                       test_mode, use_bow_features=False, use_max_pooling=False, use_lsh_features=False,
-                      include_keywords=False, include_metadata=False):
+                      include_keywords=False, include_metadata=False, use_abc_embeddings=False):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
-    prepare_classification_directory()
-    download_md_files_for_references(list(reference_curie_job_map.keys()),
-                                     "/data/agr_document_classifier/to_classify", mod_abbr)
-    expected_curies = set(reference_curie_job_map.keys())
-    downloaded_curies = {
-        os.path.splitext(f)[0].replace("_", ":")
-        for f in os.listdir("/data/agr_document_classifier/to_classify")
-        if f.endswith(".md") and ".supp_" not in f
-    }
-    missing_curies = expected_curies - downloaded_curies
-    if missing_curies:
-        logger.warning(
-            "No MD available in ABC for %d/%d references in this batch (mod=%s topic=%s); "
-            "marking those jobs failed",
-            len(missing_curies), len(expected_curies), mod_abbr, topic,
-        )
-        if not test_mode:
-            for curie in missing_curies:
-                job = reference_curie_job_map[curie]
-                set_job_started(job)
-                set_job_failure(job)
-    files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
-        embedding_model=embedding_model,
-        classifier_model=classifier_model,
-        input_docs_dir="/data/agr_document_classifier/to_classify",
-        use_bow_features=use_bow_features,
-        use_max_pooling=use_max_pooling,
-        use_lsh_features=use_lsh_features,
-        include_keywords=include_keywords,
-        include_metadata=include_metadata)
+    if use_abc_embeddings:
+        # ABC-embedding models classify from the precomputed vectors directly — no
+        # MD download and no BioWordVec/BoW/max/LSH blocks. References without an
+        # embedding come back flagged invalid and are failed in the sender below,
+        # matching the missing-MD policy of the BioWordVec path.
+        files_loaded, classifications, conf_scores, valid_embeddings = classify_documents_from_abc_embeddings(
+            list(reference_curie_job_map.keys()), mod_abbr, classifier_model)
+    else:
+        prepare_classification_directory()
+        download_md_files_for_references(list(reference_curie_job_map.keys()),
+                                         "/data/agr_document_classifier/to_classify", mod_abbr)
+        expected_curies = set(reference_curie_job_map.keys())
+        downloaded_curies = {
+            os.path.splitext(f)[0].replace("_", ":")
+            for f in os.listdir("/data/agr_document_classifier/to_classify")
+            if f.endswith(".md") and ".supp_" not in f
+        }
+        missing_curies = expected_curies - downloaded_curies
+        if missing_curies:
+            logger.warning(
+                "No MD available in ABC for %d/%d references in this batch (mod=%s topic=%s); "
+                "marking those jobs failed",
+                len(missing_curies), len(expected_curies), mod_abbr, topic,
+            )
+            if not test_mode:
+                for curie in missing_curies:
+                    job = reference_curie_job_map[curie]
+                    set_job_started(job)
+                    set_job_failure(job)
+        files_loaded, classifications, conf_scores, valid_embeddings = classify_documents(
+            embedding_model=embedding_model,
+            classifier_model=classifier_model,
+            input_docs_dir="/data/agr_document_classifier/to_classify",
+            use_bow_features=use_bow_features,
+            use_max_pooling=use_max_pooling,
+            use_lsh_features=use_lsh_features,
+            include_keywords=include_keywords,
+            include_metadata=include_metadata)
     if test_mode:
         for file_path, classification, conf_score, valid_embedding in zip(files_loaded, classifications, conf_scores,
                                                                           valid_embeddings):
@@ -316,7 +367,10 @@ def send_classification_results(files_loaded, classifications, conf_scores, vali
                     ml_model_id=model_meta_data['ml_model_id'])
         if result:
             set_job_success(reference_curie_job_map[reference_curie])
-        os.remove(file_path)
+        # Legacy path writes a real MD file to clean up here; the ABC path passes
+        # reference curies (no file on disk), so only remove when it exists.
+        if os.path.exists(file_path):
+            os.remove(file_path)
     logger.info(f"Finished processing batch of {len(files_loaded)} jobs.")
 
 

--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -95,33 +95,42 @@ def classify_documents(input_docs_dir: str, embedding_model_path: str = None, cl
     return files_loaded, classifications, confidence_scores, valid_embeddings
 
 
-def classify_documents_from_abc_embeddings(reference_curies, mod_abbr, classifier_model):
+def classify_documents_from_abc_embeddings(reference_curies, mod_abbr, classifier_model, use_bow=False):
     """Classify references using the ABC precomputed embeddings (SCRUM-5781).
 
-    The per-reference feature is the mean of the main-PDF paragraph embeddings
-    (:func:`utils.abc_utils.get_reference_embedding`). Returns the same 4-tuple
-    shape as :func:`classify_documents` — ``(ids_loaded, classifications,
-    confidence_scores, valid_embeddings)`` — but ``ids_loaded`` holds reference
-    curies rather than file paths (downstream recovers the curie from either).
+    The per-reference dense feature is the L2-normalized chunk-mean pool of the
+    main-PDF paragraph embeddings (:func:`utils.abc_utils.get_reference_embedding`);
+    when ``use_bow`` is set the hashed BoW block over the parquet's paragraph text
+    is concatenated, exactly as at train time (the model's metadata marker says
+    which). Returns the same 4-tuple shape as :func:`classify_documents` —
+    ``(ids_loaded, classifications, confidence_scores, valid_embeddings)`` — but
+    ``ids_loaded`` holds reference curies rather than file paths (downstream
+    recovers the curie from either).
 
     A reference with no available embedding is kept as a zero row flagged invalid,
     so the caller fails that job just like a missing MD in the BioWordVec path.
     """
+    bow_vectorizer = get_bow_vectorizer() if use_bow else None
     rows = []
     ids_loaded = []
     valid_embeddings = []
     for reference_curie in reference_curies:
-        vector = get_reference_embedding(reference_curie, mod_abbr)
+        result = get_reference_embedding(reference_curie, mod_abbr)
         ids_loaded.append(reference_curie)
-        if vector is None:
-            rows.append(np.zeros(ABC_EMBEDDING_DIM, dtype=np.float32))
+        if result is None:
+            pooled, text = np.zeros(ABC_EMBEDDING_DIM, dtype=np.float32), ""
             valid_embeddings.append(False)
         else:
-            rows.append(vector)
+            pooled, text = result
             valid_embeddings.append(True)
+        if use_bow:
+            bow = bow_vectorizer.transform([remove_stopwords(text).lower() if text else ""])
+            rows.append(sp.hstack([sp.csr_matrix(pooled.reshape(1, -1)), bow], format="csr"))
+        else:
+            rows.append(pooled)
     if not ids_loaded:
         return ids_loaded, np.array([]), [], valid_embeddings
-    X = np.vstack(rows)
+    X = sp.vstack(rows, format="csr") if use_bow else np.vstack(rows)
     classifications, confidence_scores = predict_labels_and_confidence(classifier_model, X)
     return ids_loaded, classifications, confidence_scores, valid_embeddings
 
@@ -230,9 +239,11 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
     # path below runs unchanged.
     abc_marker = parse_embedding_marker(model_meta_data.get("description"))
     use_abc_embeddings = abc_marker is not None
+    abc_use_bow = bool(abc_marker and abc_marker.get("bow"))
     if use_abc_embeddings:
         logger.info(f"Model for mod: {mod_abbr}, topic: {topic} uses ABC embeddings "
-                    f"(profile {abc_marker['profile_name']} v{abc_marker['version']}).")
+                    f"(profile {abc_marker['profile_name']} v{abc_marker['version']}, "
+                    f"bow={abc_use_bow}).")
 
     classification_batch_size = int(os.environ.get("CLASSIFICATION_BATCH_SIZE", 1000))
     jobs_to_process = copy.deepcopy(jobs)
@@ -249,20 +260,22 @@ def process_classification_jobs(mod_id, topic, jobs, embedding_model, test_mode=
                           test_mode, use_bow_features=use_bow_features, use_max_pooling=use_max_pooling,
                           use_lsh_features=use_lsh_features,
                           include_keywords=include_keywords, include_metadata=include_metadata,
-                          use_abc_embeddings=use_abc_embeddings)
+                          use_abc_embeddings=use_abc_embeddings, abc_use_bow=abc_use_bow)
 
 
 def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model, classifier_model, model_meta_data,
                       test_mode, use_bow_features=False, use_max_pooling=False, use_lsh_features=False,
-                      include_keywords=False, include_metadata=False, use_abc_embeddings=False):
+                      include_keywords=False, include_metadata=False, use_abc_embeddings=False,
+                      abc_use_bow=False):
     reference_curie_job_map = {job["reference_curie"]: job for job in job_batch}
     if use_abc_embeddings:
         # ABC-embedding models classify from the precomputed vectors directly — no
-        # MD download and no BioWordVec/BoW/max/LSH blocks. References without an
-        # embedding come back flagged invalid and are failed in the sender below,
-        # matching the missing-MD policy of the BioWordVec path.
+        # MD download and no BioWordVec/max/LSH blocks. The BoW block (if the model
+        # was trained with it, per its marker) is hashed from the parquet's own
+        # paragraph text. References without an embedding come back flagged invalid
+        # and are failed in the sender below, matching the missing-MD policy.
         files_loaded, classifications, conf_scores, valid_embeddings = classify_documents_from_abc_embeddings(
-            list(reference_curie_job_map.keys()), mod_abbr, classifier_model)
+            list(reference_curie_job_map.keys()), mod_abbr, classifier_model, use_bow=abc_use_bow)
     else:
         prepare_classification_directory()
         download_md_files_for_references(list(reference_curie_job_map.keys()),

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -146,15 +146,17 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
         # BoW (when enabled) is hashed from the parquet's own paragraph text, so no
         # Markdown download is needed.
         logger.info("Loading training set from ABC precomputed embeddings.")
-        X, y = _build_abc_embedding_features(abc_curies or {}, mod_abbreviation,
-                                             use_bow=use_bow_features)
+        # BoW is a fixed convention for ABC-embedding models (classify hardcodes it
+        # on too), so force it here regardless of use_bow_features — a model trained
+        # without it would mismatch feature dims at classify time.
+        X, y = _build_abc_embedding_features(abc_curies or {}, mod_abbreviation, use_bow=True)
         logger.info("Finished loading training set.")
         logger.info(f"Dataset size: {str(len(y))}")
         y = np.array(y)
-        # When BoW is on the matrix is wide+sparse, so the same SVC/MLP skip and
-        # XGBoost concurrency cap the BioWordVec path uses must apply here too.
+        # The matrix is wide+sparse (embedding + BoW), so the same SVC/MLP skip and
+        # gradient-booster concurrency cap the BioWordVec BoW path uses apply here.
         return _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination,
-                                     use_bow_features=use_bow_features, use_lsh_features=False)
+                                     use_bow_features=True, use_lsh_features=False)
 
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -650,7 +650,7 @@ def train_and_save_model(args, training_data_dir, training_set, abc_curies=None)
     # fetches ABC embeddings for it and rebuilds the identical embedding+BoW
     # vector. Legacy BioWordVec models leave those columns NULL and keep their
     # on-the-fly path.
-    embedding_recipe = abc_embedding_recipe(use_bow=True)
+    embedding_recipe = abc_embedding_recipe()
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,
                     production=args.production,

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -21,7 +21,9 @@ from sklearn.neighbors import LocalOutlierFactor
 
 from agr_dataset_manager.dataset_downloader import download_md_files_from_abc_or_convert_pdf
 from models import POSSIBLE_CLASSIFIERS
-from utils.abc_utils import get_training_set_from_abc, upload_ml_model, get_reference_date
+from utils.abc_utils import (get_training_set_from_abc, upload_ml_model, get_reference_date,
+                             get_reference_embedding)
+from utils.abc_embeddings import format_embedding_marker
 from utils.embedding import load_embedding_model, build_feature_matrix
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
@@ -89,13 +91,54 @@ def detect_and_remove_outliers(X, y, method='isolation_forest', contamination=0.
     return X_clean, y_clean, outlier_mask
 
 
+def _build_abc_embedding_features(abc_curies: dict, mod_abbreviation: str):
+    """Build ``(X, y)`` from the ABC precomputed classifier embeddings.
+
+    ``abc_curies`` maps ``"positive"``/``"negative"`` to reference-curie lists.
+    Each reference's feature is the mean of its main-PDF paragraph embeddings
+    (:func:`utils.abc_utils.get_reference_embedding`). References without an
+    available embedding are dropped and counted — the same policy the BioWordVec
+    path applies to references with no downloadable MD file."""
+    rows = []
+    y = []
+    missing = 0
+    for label in ["positive", "negative"]:
+        for reference_curie in abc_curies.get(label, []):
+            vector = get_reference_embedding(reference_curie, mod_abbreviation)
+            if vector is None:
+                missing += 1
+                continue
+            rows.append(vector)
+            y.append(int(label == "positive"))
+    if not rows:
+        raise ValueError("No ABC embeddings could be retrieved for the training set; "
+                         "cannot train. Check that the references have been embedded.")
+    logger.info(f"ABC embeddings retrieved for {len(rows)} references "
+                f"({missing} references had no embedding and were dropped).")
+    return np.vstack(rows), y
+
+
 def train_classifier(embedding_model_path: str, training_data_dir: str, weighted_average_word_embedding: bool = False,
                      standardize_embeddings: bool = False, normalize_embeddings: bool = False,
                      sections_to_use: List[str] = None, remove_outliers: bool = False,
                      outlier_method: str = 'isolation_forest', outlier_contamination: float = 0.1,
                      use_bow_features: bool = False, use_max_pooling: bool = False,
                      use_lsh_features: bool = False,
-                     include_keywords: bool = False, include_metadata: bool = False):
+                     include_keywords: bool = False, include_metadata: bool = False,
+                     use_abc_embeddings: bool = False, abc_curies: dict = None,
+                     mod_abbreviation: str = None):
+    if use_abc_embeddings:
+        # New path (SCRUM-5781): use the ABC's precomputed OpenAI embeddings instead
+        # of loading BioWordVec and pooling word vectors over downloaded Markdown.
+        logger.info("Loading training set from ABC precomputed embeddings.")
+        X, y = _build_abc_embedding_features(abc_curies or {}, mod_abbreviation)
+        logger.info("Finished loading training set.")
+        logger.info(f"Dataset size: {str(len(y))}")
+        y = np.array(y)
+        # ABC embeddings are a plain dense matrix — no sparse BoW/LSH wide-matrix
+        # handling applies, so those stay False here.
+        return _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination)
+
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 
     texts = []
@@ -145,6 +188,12 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     logger.info(f"Dataset size: {str(len(y))}")
 
     y = np.array(y)
+    return _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination,
+                                 use_bow_features=use_bow_features, use_lsh_features=use_lsh_features)
+
+
+def _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination,
+                          use_bow_features=False, use_lsh_features=False):
 
     # Step 1: Split data into train+val (80%) and holdout test set (20%)
     X_train_val, X_test, y_train_val, y_test = train_test_split(
@@ -355,7 +404,7 @@ def save_classifier(classifier, mod_abbreviation: str, topic: str,
                     data_novelty: Union[str, None],
                     production: Union[bool, None], no_data: Union[bool, None],
                     species: Union[str, None], stats: dict, dataset_id: int, test_mode: bool = False,
-                    training_data_dir: str = None):
+                    training_data_dir: str = None, description: Union[str, None] = None):
     if training_data_dir is None:
         training_data_dir = os.getenv("TRAINING_DIR", "/data/agr_document_classifier/training")
     topic_formatted = topic.replace(':', '_')
@@ -370,7 +419,8 @@ def save_classifier(classifier, mod_abbreviation: str, topic: str,
         upload_ml_model("biocuration_topic_classification", mod_abbreviation=mod_abbreviation, topic=topic,
                         data_novelty=data_novelty, production=production,
                         no_data=no_data, species=species,
-                        model_path=model_path, stats=stats, dataset_id=dataset_id, file_extension="joblib")
+                        model_path=model_path, stats=stats, dataset_id=dataset_id, file_extension="joblib",
+                        description=description)
 
 
 def save_stats_file(stats, file_path, task_type, mod_abbreviation, topic, version_num, file_extension,
@@ -429,6 +479,14 @@ def parse_arguments():
                         help="Include article metadata in the document text (off by default; must be "
                              "passed identically at classification time)",
                         required=False)
+    parser.add_argument("--use_abc_embeddings", action="store_true",
+                        help="Train on the ABC's precomputed OpenAI embeddings (profile "
+                             "'classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned') instead of "
+                             "computing BioWordVec vectors on the fly. The per-reference feature is the mean "
+                             "of the main-PDF paragraph embeddings. No MD download and no --embedding_model_path "
+                             "needed. The resulting model is tagged so the classifier fetches ABC embeddings "
+                             "for it while legacy models keep using BioWordVec.",
+                        required=False)
     parser.add_argument("-S", "--skip_training_set_download", action="store_true",
                         help="Assume that tei files from training set are already present and do not download them "
                              "again",
@@ -467,11 +525,10 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def download_training_set(args, training_data_dir):
-    # Get training set with optional version
-    training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
-                                             version=args.dataset_version)
-
+def get_filtered_training_curies(args, training_set):
+    """Split a training set into positive/negative reference-curie lists, applying
+    the optional ``--filter_date_before`` cutoff. Returns
+    ``{"positive": [...], "negative": [...]}``."""
     reference_ids_positive = [agrkbid for agrkbid, classification_value in training_set["data_training"].items() if
                               classification_value == "positive"]
     reference_ids_negative = [agrkbid for agrkbid, classification_value in training_set["data_training"].items() if
@@ -510,6 +567,18 @@ def download_training_set(args, training_data_dir):
         reference_ids_positive = filtered_positive
         reference_ids_negative = filtered_negative
 
+    return {"positive": reference_ids_positive, "negative": reference_ids_negative}
+
+
+def download_training_set(args, training_data_dir):
+    # Get training set with optional version
+    training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
+                                             version=args.dataset_version)
+
+    curies = get_filtered_training_curies(args, training_set)
+    reference_ids_positive = curies["positive"]
+    reference_ids_negative = curies["negative"]
+
     shutil.rmtree(os.path.join(training_data_dir, "positive"), ignore_errors=True)
     shutil.rmtree(os.path.join(training_data_dir, "negative"), ignore_errors=True)
     os.makedirs(os.path.join(training_data_dir, "positive"), exist_ok=True)
@@ -540,7 +609,7 @@ def upload_pre_existing_model(args, training_set, training_data_dir):
                     stats=stats, dataset_id=training_set["dataset_id"], file_extension="joblib")
 
 
-def train_and_save_model(args, training_data_dir, training_set):
+def train_and_save_model(args, training_data_dir, training_set, abc_curies=None):
     if args.test_mode:
         logger.info("Running in test mode. Model will be saved locally and not uploaded to ABC.")
     classifier, stats = train_classifier(
@@ -557,18 +626,37 @@ def train_and_save_model(args, training_data_dir, training_set):
         use_max_pooling=args.use_max_pooling,
         use_lsh_features=args.use_lsh_features,
         include_keywords=args.include_keywords,
-        include_metadata=args.include_metadata)
+        include_metadata=args.include_metadata,
+        use_abc_embeddings=args.use_abc_embeddings,
+        abc_curies=abc_curies,
+        mod_abbreviation=args.mod_train)
     logger.info(f"Best classifier stats: {str(stats)}")
+    # Tag ABC-embedding models so the classifier fetches ABC embeddings for them;
+    # legacy (BioWordVec) models carry no marker and keep their on-the-fly path.
+    description = format_embedding_marker() if args.use_abc_embeddings else None
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,
                     production=args.production,
                     no_data=not args.do_not_flag_no_data, species=args.alternative_species,
                     stats=stats, dataset_id=training_set["dataset_id"], test_mode=args.test_mode,
-                    training_data_dir=training_data_dir)
+                    training_data_dir=training_data_dir, description=description)
 
 
 def train_mode(args):
     training_data_dir = os.getenv("TRAINING_DIR", "/data/agr_document_classifier/training")
+    if args.use_abc_embeddings:
+        # ABC-embedding path: no MD download, we only need the metadata (dataset_id)
+        # plus the positive/negative curie lists to fetch precomputed embeddings.
+        logger.info("Using ABC precomputed embeddings; skipping MD/TEI download.")
+        training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
+                                                 metadata_only=False, version=args.dataset_version)
+        abc_curies = get_filtered_training_curies(args, training_set)
+        if args.skip_training:
+            upload_pre_existing_model(args, training_set, training_data_dir)
+        else:
+            train_and_save_model(args, training_data_dir, training_set, abc_curies=abc_curies)
+        return
+
     if args.skip_training_set_download:
         logger.info("Skipping training set download")
         training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
@@ -587,6 +675,10 @@ def main():
         if not re.search(r'^NCBITaxon:\d+$', args.alternative_species):
             print("Invalid alternative species specified. Must start with 'NCBITaxon:' followed by numbers ONLY")
             sys.exit(1)
+    # The BioWordVec path needs a word-embedding model; the ABC-embedding path does not.
+    if not args.use_abc_embeddings and not args.skip_training and not args.embedding_model_path:
+        print("--embedding_model_path is required unless --use_abc_embeddings is set.")
+        sys.exit(1)
     configure_logging(args.log_level)
 
     train_mode(args)

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -495,14 +495,6 @@ def parse_arguments():
                         help="Include article metadata in the document text (off by default; must be "
                              "passed identically at classification time)",
                         required=False)
-    parser.add_argument("--use_abc_embeddings", action="store_true",
-                        help="Train on the ABC's precomputed OpenAI embeddings (profile "
-                             "'classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned') instead of "
-                             "computing BioWordVec vectors on the fly. The per-reference feature is the mean "
-                             "of the main-PDF paragraph embeddings. No MD download and no --embedding_model_path "
-                             "needed. The resulting model is tagged so the classifier fetches ABC embeddings "
-                             "for it while legacy models keep using BioWordVec.",
-                        required=False)
     parser.add_argument("-S", "--skip_training_set_download", action="store_true",
                         help="Assume that tei files from training set are already present and do not download them "
                              "again",
@@ -528,8 +520,9 @@ def parse_arguments():
                                                                  "locally.", required=False)
     parser.add_argument("--dataset_version", type=int, required=False,
                         help="Specific dataset version to use for training (defaults to latest)")
-    parser.add_argument("--filter_date_before", type=str, required=False,
-                        help="Filter out references published before this date (YYYY-MM-DD format)")
+    parser.add_argument("--filter_date_before", type=str, required=False, default="2005-01-01",
+                        help="Filter out references published before this date (YYYY-MM-DD format). "
+                             "Defaults to 2005-01-01; pass an empty string to disable date filtering.")
     # Outlier detection arguments
     parser.add_argument("--remove_outliers", action="store_true",
                         help="Enable outlier detection and removal")
@@ -628,6 +621,9 @@ def upload_pre_existing_model(args, training_set, training_data_dir):
 def train_and_save_model(args, training_data_dir, training_set, abc_curies=None):
     if args.test_mode:
         logger.info("Running in test mode. Model will be saved locally and not uploaded to ABC.")
+    # ABC precomputed embeddings + hashed BoW are the standard training recipe now
+    # (SCRUM-5781/6052): embedding alone underperformed BoW, embedding+BoW matched
+    # the BoW baseline, so both are always used.
     classifier, stats = train_classifier(
         embedding_model_path=args.embedding_model_path,
         training_data_dir=training_data_dir,
@@ -638,21 +634,19 @@ def train_and_save_model(args, training_data_dir, training_set, abc_curies=None)
         remove_outliers=args.remove_outliers,
         outlier_method=args.outlier_method,
         outlier_contamination=args.outlier_contamination,
-        use_bow_features=args.use_bow_features,
+        use_bow_features=True,
         use_max_pooling=args.use_max_pooling,
         use_lsh_features=args.use_lsh_features,
         include_keywords=args.include_keywords,
         include_metadata=args.include_metadata,
-        use_abc_embeddings=args.use_abc_embeddings,
+        use_abc_embeddings=True,
         abc_curies=abc_curies,
         mod_abbreviation=args.mod_train)
     logger.info(f"Best classifier stats: {str(stats)}")
-    # Tag ABC-embedding models so the classifier fetches ABC embeddings for them
-    # (and records whether BoW was concatenated, so classify rebuilds the identical
-    # feature vector); legacy (BioWordVec) models carry no marker and keep their
-    # on-the-fly path.
-    description = (format_embedding_marker(use_bow=args.use_bow_features)
-                   if args.use_abc_embeddings else None)
+    # Tag the model so the classifier fetches ABC embeddings for it (and rebuilds
+    # the identical embedding+BoW vector). Legacy BioWordVec models carry no marker
+    # and keep their on-the-fly path.
+    description = format_embedding_marker(use_bow=True)
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,
                     production=args.production,
@@ -662,30 +656,18 @@ def train_and_save_model(args, training_data_dir, training_set, abc_curies=None)
 
 
 def train_mode(args):
+    # ABC precomputed embeddings are the default (and only) training source now.
+    # We need the dataset metadata (dataset_id) plus the positive/negative curie
+    # lists to fetch the embeddings; no MD/TEI download.
     training_data_dir = os.getenv("TRAINING_DIR", "/data/agr_document_classifier/training")
-    if args.use_abc_embeddings:
-        # ABC-embedding path: no MD download, we only need the metadata (dataset_id)
-        # plus the positive/negative curie lists to fetch precomputed embeddings.
-        logger.info("Using ABC precomputed embeddings; skipping MD/TEI download.")
-        training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
-                                                 metadata_only=False, version=args.dataset_version)
-        abc_curies = get_filtered_training_curies(args, training_set)
-        if args.skip_training:
-            upload_pre_existing_model(args, training_set, training_data_dir)
-        else:
-            train_and_save_model(args, training_data_dir, training_set, abc_curies=abc_curies)
-        return
-
-    if args.skip_training_set_download:
-        logger.info("Skipping training set download")
-        training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
-                                                 metadata_only=True, version=args.dataset_version)
-    else:
-        training_set = download_training_set(args, training_data_dir)
+    logger.info("Training on ABC precomputed embeddings (default).")
+    training_set = get_training_set_from_abc(mod_abbreviation=args.mod_train, topic=args.datatype_train,
+                                             metadata_only=False, version=args.dataset_version)
+    abc_curies = get_filtered_training_curies(args, training_set)
     if args.skip_training:
         upload_pre_existing_model(args, training_set, training_data_dir)
     else:
-        train_and_save_model(args, training_data_dir, training_set)
+        train_and_save_model(args, training_data_dir, training_set, abc_curies=abc_curies)
 
 
 def main():
@@ -694,10 +676,6 @@ def main():
         if not re.search(r'^NCBITaxon:\d+$', args.alternative_species):
             print("Invalid alternative species specified. Must start with 'NCBITaxon:' followed by numbers ONLY")
             sys.exit(1)
-    # The BioWordVec path needs a word-embedding model; the ABC-embedding path does not.
-    if not args.use_abc_embeddings and not args.skip_training and not args.embedding_model_path:
-        print("--embedding_model_path is required unless --use_abc_embeddings is set.")
-        sys.exit(1)
     configure_logging(args.log_level)
 
     train_mode(args)

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -25,7 +25,7 @@ from agr_dataset_manager.dataset_downloader import download_md_files_from_abc_or
 from models import POSSIBLE_CLASSIFIERS
 from utils.abc_utils import (get_training_set_from_abc, upload_ml_model, get_reference_date,
                              get_reference_embedding)
-from utils.abc_embeddings import format_embedding_marker
+from utils.abc_embeddings import abc_embedding_recipe
 from utils.embedding import load_embedding_model, build_feature_matrix, get_bow_vectorizer
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
@@ -423,7 +423,7 @@ def save_classifier(classifier, mod_abbreviation: str, topic: str,
                     data_novelty: Union[str, None],
                     production: Union[bool, None], no_data: Union[bool, None],
                     species: Union[str, None], stats: dict, dataset_id: int, test_mode: bool = False,
-                    training_data_dir: str = None, description: Union[str, None] = None):
+                    training_data_dir: str = None, embedding_recipe: Union[dict, None] = None):
     if training_data_dir is None:
         training_data_dir = os.getenv("TRAINING_DIR", "/data/agr_document_classifier/training")
     topic_formatted = topic.replace(':', '_')
@@ -439,7 +439,7 @@ def save_classifier(classifier, mod_abbreviation: str, topic: str,
                         data_novelty=data_novelty, production=production,
                         no_data=no_data, species=species,
                         model_path=model_path, stats=stats, dataset_id=dataset_id, file_extension="joblib",
-                        description=description)
+                        embedding_recipe=embedding_recipe)
 
 
 def save_stats_file(stats, file_path, task_type, mod_abbreviation, topic, version_num, file_extension,
@@ -646,16 +646,17 @@ def train_and_save_model(args, training_data_dir, training_set, abc_curies=None)
         abc_curies=abc_curies,
         mod_abbreviation=args.mod_train)
     logger.info(f"Best classifier stats: {str(stats)}")
-    # Tag the model so the classifier fetches ABC embeddings for it (and rebuilds
-    # the identical embedding+BoW vector). Legacy BioWordVec models carry no marker
-    # and keep their on-the-fly path.
-    description = format_embedding_marker(use_bow=True)
+    # Tag the model (via the ml_model embedding_* columns) so the classifier
+    # fetches ABC embeddings for it and rebuilds the identical embedding+BoW
+    # vector. Legacy BioWordVec models leave those columns NULL and keep their
+    # on-the-fly path.
+    embedding_recipe = abc_embedding_recipe(use_bow=True)
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,
                     production=args.production,
                     no_data=not args.do_not_flag_no_data, species=args.alternative_species,
                     stats=stats, dataset_id=training_set["dataset_id"], test_mode=args.test_mode,
-                    training_data_dir=training_data_dir, description=description)
+                    training_data_dir=training_data_dir, embedding_recipe=embedding_recipe)
 
 
 def train_mode(args):

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -9,6 +9,7 @@ import sys
 from datetime import datetime
 from typing import List, Union
 
+import utils.thread_limits  # noqa: F401  (import first: pins native threads to 1)
 import joblib
 import nltk
 import numpy as np

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -266,16 +266,18 @@ def _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contami
         n_iter = 50 if classifier_name in ['LogisticRegression', 'SGDClassifier'] else 30
 
         # RandomizedSearchCV fans every candidate fit out to its own worker
-        # process. On the wide sparse BoW/LSH matrix (2**18 columns) an XGBoost
-        # worker allocates gradient-histogram buffers sized by n_features
-        # (~3 GB per fit), so the default n_jobs=-1 (one worker per core) peaked
-        # at ~51 GB on the largest dataset and systemd-oomd killed the whole user
-        # slice. Cap XGBoost's *search* concurrency on wide matrices; the lighter
-        # models materialise far less and ran fine at full width. n_jobs does not
-        # change the result (the search is deterministic given random_state), so
-        # model-selection stats are unaffected. Override with SEARCH_MAX_JOBS.
+        # process. On the wide sparse BoW/LSH matrix (2**18 columns) a worker
+        # allocates buffers sized by n_features (XGBoost gradient histograms
+        # ~3 GB/fit; LightGBM feature histograms similarly), so the default
+        # n_jobs=-1 (one worker per core) peaks memory and a worker gets OS-killed
+        # (SIGSEGV) — reproduced on the larger FB training sets (e.g. disease,
+        # ~2774 refs) where LightGBM crashed even with native threads pinned to 1,
+        # while the smaller sets (~1500 refs) survived. Cap the *search* concurrency
+        # for every model on wide matrices; n_jobs does not change the result (the
+        # search is deterministic given random_state), so model-selection stats are
+        # unaffected. Override with SEARCH_MAX_JOBS.
         search_n_jobs = -1
-        if (use_bow_features or use_lsh_features) and classifier_name == 'XGBClassifier':
+        if use_bow_features or use_lsh_features:
             search_n_jobs = int(os.environ.get('SEARCH_MAX_JOBS', '4'))
 
         random_search = RandomizedSearchCV(

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -12,6 +12,7 @@ from typing import List, Union
 import joblib
 import nltk
 import numpy as np
+import scipy.sparse as sp
 from gensim.models import KeyedVectors
 from sklearn.metrics import make_scorer, precision_score, recall_score, f1_score
 from sklearn.model_selection import RandomizedSearchCV, StratifiedKFold, train_test_split
@@ -24,7 +25,7 @@ from models import POSSIBLE_CLASSIFIERS
 from utils.abc_utils import (get_training_set_from_abc, upload_ml_model, get_reference_date,
                              get_reference_embedding)
 from utils.abc_embeddings import format_embedding_marker
-from utils.embedding import load_embedding_model, build_feature_matrix
+from utils.embedding import load_embedding_model, build_feature_matrix, get_bow_vectorizer
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
 
@@ -91,31 +92,42 @@ def detect_and_remove_outliers(X, y, method='isolation_forest', contamination=0.
     return X_clean, y_clean, outlier_mask
 
 
-def _build_abc_embedding_features(abc_curies: dict, mod_abbreviation: str):
+def _build_abc_embedding_features(abc_curies: dict, mod_abbreviation: str, use_bow: bool = False):
     """Build ``(X, y)`` from the ABC precomputed classifier embeddings.
 
     ``abc_curies`` maps ``"positive"``/``"negative"`` to reference-curie lists.
-    Each reference's feature is the mean of its main-PDF paragraph embeddings
-    (:func:`utils.abc_utils.get_reference_embedding`). References without an
-    available embedding are dropped and counted — the same policy the BioWordVec
-    path applies to references with no downloadable MD file."""
+    Each reference's dense feature is the L2-normalized chunk-mean pool of its
+    main-PDF paragraph embeddings (:func:`utils.abc_utils.get_reference_embedding`).
+    When ``use_bow`` is set, the same stateless hashed bag-of-words block the
+    BioWordVec classifiers use is concatenated onto the embedding — hashed over the
+    references-excluded paragraph text carried in the parquet — yielding a sparse
+    matrix (SCRUM-6052 recipe). References without an available embedding are
+    dropped and counted, the same policy the BioWordVec path applies to references
+    with no downloadable MD file."""
     rows = []
     y = []
     missing = 0
+    bow_vectorizer = get_bow_vectorizer() if use_bow else None
     for label in ["positive", "negative"]:
         for reference_curie in abc_curies.get(label, []):
-            vector = get_reference_embedding(reference_curie, mod_abbreviation)
-            if vector is None:
+            result = get_reference_embedding(reference_curie, mod_abbreviation)
+            if result is None:
                 missing += 1
                 continue
-            rows.append(vector)
+            pooled, text = result
+            if use_bow:
+                bow = bow_vectorizer.transform([remove_stopwords(text).lower() if text else ""])
+                rows.append(sp.hstack([sp.csr_matrix(pooled.reshape(1, -1)), bow], format="csr"))
+            else:
+                rows.append(pooled)
             y.append(int(label == "positive"))
     if not rows:
         raise ValueError("No ABC embeddings could be retrieved for the training set; "
                          "cannot train. Check that the references have been embedded.")
     logger.info(f"ABC embeddings retrieved for {len(rows)} references "
-                f"({missing} references had no embedding and were dropped).")
-    return np.vstack(rows), y
+                f"({missing} references had no embedding and were dropped). BoW={use_bow}.")
+    X = sp.vstack(rows, format="csr") if use_bow else np.vstack(rows)
+    return X, y
 
 
 def train_classifier(embedding_model_path: str, training_data_dir: str, weighted_average_word_embedding: bool = False,
@@ -130,14 +142,18 @@ def train_classifier(embedding_model_path: str, training_data_dir: str, weighted
     if use_abc_embeddings:
         # New path (SCRUM-5781): use the ABC's precomputed OpenAI embeddings instead
         # of loading BioWordVec and pooling word vectors over downloaded Markdown.
+        # BoW (when enabled) is hashed from the parquet's own paragraph text, so no
+        # Markdown download is needed.
         logger.info("Loading training set from ABC precomputed embeddings.")
-        X, y = _build_abc_embedding_features(abc_curies or {}, mod_abbreviation)
+        X, y = _build_abc_embedding_features(abc_curies or {}, mod_abbreviation,
+                                             use_bow=use_bow_features)
         logger.info("Finished loading training set.")
         logger.info(f"Dataset size: {str(len(y))}")
         y = np.array(y)
-        # ABC embeddings are a plain dense matrix — no sparse BoW/LSH wide-matrix
-        # handling applies, so those stay False here.
-        return _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination)
+        # When BoW is on the matrix is wide+sparse, so the same SVC/MLP skip and
+        # XGBoost concurrency cap the BioWordVec path uses must apply here too.
+        return _select_and_fit_model(X, y, remove_outliers, outlier_method, outlier_contamination,
+                                     use_bow_features=use_bow_features, use_lsh_features=False)
 
     embedding_model = load_embedding_model(model_path=embedding_model_path)
 
@@ -631,9 +647,12 @@ def train_and_save_model(args, training_data_dir, training_set, abc_curies=None)
         abc_curies=abc_curies,
         mod_abbreviation=args.mod_train)
     logger.info(f"Best classifier stats: {str(stats)}")
-    # Tag ABC-embedding models so the classifier fetches ABC embeddings for them;
-    # legacy (BioWordVec) models carry no marker and keep their on-the-fly path.
-    description = format_embedding_marker() if args.use_abc_embeddings else None
+    # Tag ABC-embedding models so the classifier fetches ABC embeddings for them
+    # (and records whether BoW was concatenated, so classify rebuilds the identical
+    # feature vector); legacy (BioWordVec) models carry no marker and keep their
+    # on-the-fly path.
+    description = (format_embedding_marker(use_bow=args.use_bow_features)
+                   if args.use_abc_embeddings else None)
     save_classifier(classifier=classifier, mod_abbreviation=args.mod_train, topic=args.datatype_train,
                     data_novelty=args.data_novelty,
                     production=args.production,

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -43,13 +43,15 @@ already in production working exactly as before.
    "converted_merged_main"`. Supplement embeddings are ignored.
 5. **Retrocompat via dedicated `ml_model` columns** (not a global date cutoff):
    dedicated nullable columns are added to `ml_model` (agr_literature_service,
-   branch SCRUM-5781) — `embedding_profile`, `embedding_version`, `embedding_model`,
-   `embedding_dim`, `embedding_pooling`, `use_bow_features` — NULL for legacy models.
-   The trainer sets them at upload; the classifier reads them per model —
-   `embedding_profile` set ⇒ ABC-embedding path (rebuilding the identical
-   embedding[+BoW] vector); NULL/absent ⇒ the existing BioWordVec on-the-fly path,
-   byte-for-byte unchanged. (Earlier iterations stored this in
-   `description`/`parameters`; dedicated columns are cleaner and queryable.)
+   branch SCRUM-5781) — **`embedding_profile` + `embedding_version`** only — NULL
+   for legacy models. That pair is all the classifier needs *before* fetching, to
+   select which stored embedding to pull; pooling (L2 chunk-mean) and the BoW block
+   are fixed conventions applied to every ABC-embedding model (not stored), and
+   model/dim live in the parquet. The trainer sets the pair at upload; the
+   classifier reads it per model — `embedding_profile` set ⇒ ABC-embedding path;
+   NULL/absent ⇒ the existing BioWordVec on-the-fly path, byte-for-byte unchanged.
+   (Earlier iterations stored this in `description`/`parameters`; dedicated columns
+   are cleaner and queryable.)
 6. **Scope of retraining:** the five FB document-classification topics with a
    training dataset — disease (`ATP:0000152`), new transgene (`ATP:0000013`), new
    allele (`ATP:0000006`), physical interaction (`ATP:0000069`), and "no genetic
@@ -98,11 +100,10 @@ Single source of truth for the profile constants + the recipe helpers + parquet 
   - False ⇒ current BioWordVec path, unchanged.
 
 ### Backend `agr_literature_service` (branch SCRUM-5781)
-- Nullable `ml_model` columns `embedding_profile`/`embedding_version`/
-  `embedding_model`/`embedding_dim`/`embedding_pooling`/`use_bow_features`, wired
+- Nullable `ml_model` columns `embedding_profile` + `embedding_version`, wired
   through the create schema, `/ml_model/upload` Form params, and the crud
   (persist + return). Alembic migration generated separately + deployed before any
-  marked model is promoted to production.
+  ABC-embedding model is promoted to production.
 - The BioWordVec embedding model is still loaded once for the mixed run; ABC-marked
   models ignore it.
 

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -28,21 +28,30 @@ already in production working exactly as before.
 
 ## Decisions (confirmed with PO)
 
-1. **Feature = mean of the paragraph-level embeddings** in the main-PDF parquet
-   (rows with `is_document_level == False`), producing one 1536-d vector per
-   reference. The document-level row is ignored.
-2. **Main PDF only:** select the embedding whose `source.file_class ==
+1. **Dense feature = L2-normalized chunk-mean pool** of the main-PDF paragraph
+   embeddings (each paragraph vector L2-normalized, averaged, mean L2-normalized;
+   `is_document_level` row excluded) — the SCRUM-6052 recipe.
+2. **Concatenate the hashed BoW block** (`--use_bow_features`) over the parquet's
+   own references-excluded paragraph text. Rationale (SCRUM-6052): the embedding
+   alone underperformed BoW; embedding+BoW matched the BoW baseline. BoW text is
+   taken from the parquet content (not a separate MD download) so classify needs
+   only the parquet; this is a deliberate, transparent deviation from the
+   prototype's MD-fulltext BoW with negligible expected impact.
+3. **Date threshold** `--filter_date_before 2005-01-01`; **no outlier removal**
+   (PO found it gave no advantage).
+4. **Main PDF only:** select the embedding whose `source.file_class ==
    "converted_merged_main"`. Supplement embeddings are ignored.
-3. **Retrocompat via a per-model marker** (not a global date cutoff): the trainer
-   stamps a machine-readable marker into the model's ABC `ml_model.description`.
-   The classifier reads it per model — marker present ⇒ ABC-embedding path; absent
-   ⇒ the existing BioWordVec on-the-fly path, byte-for-byte unchanged. This needs
-   **no ABC schema change**: the `description` column already exists, the
-   `/ml_model/upload` endpoint already accepts it, and `get_model_data` already
-   returns it.
-4. **Scope of retraining:** all FB document-classification topics that have a
-   training dataset on the target ABC, plus the "no genetic data" classifier
-   (FB `ATP:0000207`). Upload to dev/stage with `production=false`.
+5. **Retrocompat via a per-model marker** (not a global date cutoff): the trainer
+   stamps a machine-readable marker into the model's ABC `ml_model.description`,
+   including `bow=true/false`. The classifier reads it per model — marker present ⇒
+   ABC-embedding path (rebuilding the identical embedding[+BoW] vector); absent ⇒
+   the existing BioWordVec on-the-fly path, byte-for-byte unchanged. No ABC schema
+   change: `description` already exists on `/ml_model/upload` and `get_model_data`.
+6. **Scope of retraining:** the five FB document-classification topics with a
+   training dataset — disease (`ATP:0000152`), new transgene (`ATP:0000013`), new
+   allele (`ATP:0000006`), physical interaction (`ATP:0000069`), and "no genetic
+   data" (`ATP:0000207`). Read datasets + embeddings from prod (the only place FB
+   embeddings currently exist); upload to stage with `production=false`.
 
 ## Components
 

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -97,6 +97,15 @@ curie ─ show_all ─▶ embedding row (profile match, source=converted_merged_
   needed on the consumer side (reading only). Install `pyarrow` in the cervino
   conda env before training.
 
+## Cross-environment upload (operational)
+The FB embeddings currently exist only on **prod** (verified 2026-07-16: prod
+10/10 sample references embedded, stage 0/10), while the FB datasets exist on both
+with the same `dataset_id`. To honor "train + upload to stage" without embeddings
+on stage, `upload_ml_model` honors an optional `ABC_UPLOAD_API_SERVER` env var that
+redirects **only** the model upload. A run therefore reads datasets + embeddings
+from prod (`ABC_API_SERVER=…prod…`) and uploads the model to stage
+(`ABC_UPLOAD_API_SERVER=…stage…`), all with `production=false`.
+
 ## Testing
 - Unit tests with a synthetic parquet (pyarrow) and mocked `show_all`/download:
   - `paragraph_mean_from_parquet` averages only paragraph rows; `None` on

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -41,12 +41,15 @@ already in production working exactly as before.
    (PO found it gave no advantage).
 4. **Main PDF only:** select the embedding whose `source.file_class ==
    "converted_merged_main"`. Supplement embeddings are ignored.
-5. **Retrocompat via a per-model marker** (not a global date cutoff): the trainer
-   stamps a machine-readable marker into the model's ABC `ml_model.description`,
-   including `bow=true/false`. The classifier reads it per model — marker present ⇒
-   ABC-embedding path (rebuilding the identical embedding[+BoW] vector); absent ⇒
-   the existing BioWordVec on-the-fly path, byte-for-byte unchanged. No ABC schema
-   change: `description` already exists on `/ml_model/upload` and `get_model_data`.
+5. **Retrocompat via dedicated `ml_model` columns** (not a global date cutoff):
+   dedicated nullable columns are added to `ml_model` (agr_literature_service,
+   branch SCRUM-5781) — `embedding_profile`, `embedding_version`, `embedding_model`,
+   `embedding_dim`, `embedding_pooling`, `use_bow_features` — NULL for legacy models.
+   The trainer sets them at upload; the classifier reads them per model —
+   `embedding_profile` set ⇒ ABC-embedding path (rebuilding the identical
+   embedding[+BoW] vector); NULL/absent ⇒ the existing BioWordVec on-the-fly path,
+   byte-for-byte unchanged. (Earlier iterations stored this in
+   `description`/`parameters`; dedicated columns are cleaner and queryable.)
 6. **Scope of retraining:** the five FB document-classification topics with a
    training dataset — disease (`ATP:0000152`), new transgene (`ATP:0000013`), new
    allele (`ATP:0000006`), physical interaction (`ATP:0000069`), and "no genetic
@@ -56,24 +59,25 @@ already in production working exactly as before.
 ## Components
 
 ### New: `utils/abc_embeddings.py`
-Single source of truth for the profile constants + marker format + parquet read.
+Single source of truth for the profile constants + the recipe helpers + parquet read.
 
 - Constants: `ABC_EMBEDDING_PROFILE`, `ABC_EMBEDDING_VERSION`,
-  `ABC_EMBEDDING_MODEL`, `ABC_EMBEDDING_DIM`, `ABC_EMBEDDING_POOLING="paragraph_mean"`.
-- `format_embedding_marker(...) -> str` / `parse_embedding_marker(description) -> dict|None`:
-  a sentinel-prefixed `key=value` marker, tolerant parsing. Detection is by the
-  sentinel token; absence ⇒ `None`.
-- `paragraph_mean_from_parquet(parquet_bytes) -> np.ndarray|None`: read the parquet
-  from bytes with `pyarrow`, average the `embedding` of rows where
-  `is_document_level` is false. `None` when there are no paragraph rows.
+  `ABC_EMBEDDING_MODEL`, `ABC_EMBEDDING_DIM`, `ABC_EMBEDDING_POOLING="l2_chunk_mean"`.
+- `abc_embedding_recipe(use_bow) -> dict`: the `ml_model` embedding_* column values
+  to stamp at upload. `is_abc_embedding_model(model_meta_data) -> bool`: True when
+  `embedding_profile` is set.
+- `paragraph_pool_and_text(parquet_bytes) -> (np.ndarray, str)|None`: read the
+  parquet with `pyarrow`; L2-normalized chunk-mean pool of the paragraph rows
+  (`is_document_level` false) + their concatenated `content` (for BoW). `None` when
+  there are no paragraph rows.
 
 ### `utils/abc_utils.py`
-- `get_reference_embedding(reference_curie, mod_abbreviation, profile_name, version) -> np.ndarray|None`:
+- `get_reference_embedding(reference_curie, mod_abbreviation, ...) -> (np.ndarray, str)|None`:
   `show_all` → pick the `embedding` row with the matching `profile_name`/`version`
   whose `source.file_class == "converted_merged_main"` → download parquet →
-  `paragraph_mean_from_parquet`. `None` when the reference has no such embedding.
-- `upload_ml_model(...)`: add an optional `description` parameter, sent as a form
-  field in the upload payload.
+  `paragraph_pool_and_text`. `None` when the reference has no such embedding.
+- `upload_ml_model(...)`: optional `embedding_recipe` dict merged into the upload
+  form payload (the `ml_model` embedding_* columns).
 
 ### Trainer `agr_document_classifier_trainer.py`
 - ABC embeddings are the **default (and only) training source** — there is no
@@ -82,16 +86,23 @@ Single source of truth for the profile constants + marker format + parquet read.
   BoW block (always on). References with no embedding are dropped and logged (same
   policy as a missing MD). `--filter_date_before` defaults to `2005-01-01`; pass an
   empty string to disable. No MD download and no `--embedding_model_path` needed.
-- Stamp the marker (`bow=true`) into `description` and pass it to `upload_ml_model`.
+- Stamps `abc_embedding_recipe(use_bow=True)` into the model via `upload_ml_model`.
 - The BioWordVec `train_classifier(use_abc_embeddings=False)` path remains for
   programmatic/test use but is not reachable from the CLI.
 
 ### Classifier `agr_document_classifier_classify.py`
-- Per model, after `get_model_data`, parse `description` for the marker.
-  - Marker present ⇒ for each reference in the batch fetch the ABC paragraph-mean
-    vector and predict on it; a reference with no embedding is treated as an
-    invalid embedding (job failed) exactly like a missing MD today.
-  - Marker absent ⇒ current BioWordVec path, unchanged.
+- Per model, after `get_model_data`, `is_abc_embedding_model(metadata)` decides:
+  - True ⇒ for each reference in the batch fetch the ABC paragraph-mean vector
+    (+ BoW when `use_bow_features`) and predict; a reference with no embedding is
+    treated as an invalid embedding (job failed) exactly like a missing MD today.
+  - False ⇒ current BioWordVec path, unchanged.
+
+### Backend `agr_literature_service` (branch SCRUM-5781)
+- Nullable `ml_model` columns `embedding_profile`/`embedding_version`/
+  `embedding_model`/`embedding_dim`/`embedding_pooling`/`use_bow_features`, wired
+  through the create schema, `/ml_model/upload` Form params, and the crud
+  (persist + return). Alembic migration generated separately + deployed before any
+  marked model is promoted to production.
 - The BioWordVec embedding model is still loaded once for the mixed run; ABC-marked
   models ignore it.
 
@@ -119,11 +130,13 @@ from prod (`ABC_API_SERVER=…prod…`) and uploads the model to stage
 
 ## Testing
 - Unit tests with a synthetic parquet (pyarrow) and mocked `show_all`/download:
-  - `paragraph_mean_from_parquet` averages only paragraph rows; `None` on
-    doc-level-only.
+  - `paragraph_pool_and_text` L2-normalized-chunk-mean over paragraph rows only;
+    `None` on doc-level-only.
   - `get_reference_embedding` selects the `converted_merged_main` profile row and
     ignores supplements / wrong profile / missing embedding.
-  - marker round-trip (`format`/`parse`), and absence ⇒ `None` (retrocompat gate).
+  - `abc_embedding_recipe` fields; `is_abc_embedding_model` gate (profile set ⇒
+    True, NULL/absent ⇒ False — the retrocompat switch).
+  - `upload_ml_model` merges the recipe into the upload form fields.
 
 ## Out of scope
 - WB retraining (SCRUM-5780), abstract embeddings, paragraph-level (non-pooled)

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -76,13 +76,15 @@ Single source of truth for the profile constants + marker format + parquet read.
   field in the upload payload.
 
 ### Trainer `agr_document_classifier_trainer.py`
-- New flag `--use_abc_embeddings`. When set:
-  - `--embedding_model_path` is not required (no BioWordVec load).
-  - Build `X` from the ABC paragraph-mean vector of each positive/negative curie
-    (references with no embedding are dropped and logged — same policy as a
-    missing MD today). No MD download, no text pipeline, no BoW/max/LSH blocks.
-  - Stamp the marker into `description` and pass it to `upload_ml_model`.
-- The existing BioWordVec path is untouched when the flag is off.
+- ABC embeddings are the **default (and only) training source** — there is no
+  `--use_abc_embeddings` flag. Every run builds `X` from the L2-chunk-mean pool of
+  each positive/negative curie's main-PDF embedding, concatenated with the hashed
+  BoW block (always on). References with no embedding are dropped and logged (same
+  policy as a missing MD). `--filter_date_before` defaults to `2005-01-01`; pass an
+  empty string to disable. No MD download and no `--embedding_model_path` needed.
+- Stamp the marker (`bow=true`) into `description` and pass it to `upload_ml_model`.
+- The BioWordVec `train_classifier(use_abc_embeddings=False)` path remains for
+  programmatic/test use but is not reachable from the CLI.
 
 ### Classifier `agr_document_classifier_classify.py`
 - Per model, after `get_model_data`, parse `description` for the marker.

--- a/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
+++ b/docs/superpowers/specs/2026-07-16-scrum-5781-classifier-abc-embeddings-design.md
@@ -1,0 +1,110 @@
+# SCRUM-5781 — Consume ABC precomputed embeddings in the document classifier
+
+**Ticket:** SCRUM-5781 "Retrain FB models on new full text" (epic SCRUM-5990 "Update
+pipelines after embedding db instantiated").
+
+**Goal:** Let the document-classifier trainer and classifier use the OpenAI
+embeddings the ABC now produces per reference (SCRUM-6141/6142), instead of
+computing BioWordVec mean-pooled vectors on the fly — while keeping every model
+already in production working exactly as before.
+
+## Background (what the ABC already provides)
+
+- After PDF→MD conversion, the ABC generates one **embedding parquet per merged
+  Markdown** and registers it as a `referencefile` with `file_class="embedding"`,
+  `file_extension="parquet"` (producer: `embedding_generation.py`).
+- Exactly one profile exists today:
+  - `profile_name = classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned`
+  - `version = 1`, `model = text-embedding-3-small`, `dim = 1536`
+- The parquet has one row per **paragraph chunk** plus one **document-level** row
+  (`is_document_level == True`). Columns are the shared contract in
+  `agr_abc_document_parsers.embeddings.parquet_io` (`embedding` is `list<float32>`).
+- Discovery: `GET /reference/referencefile/show_all/{curie}` lists embedding rows,
+  each enriched with `profile_name`, `version`, `model_name`, and a `source`
+  pointer to the `converted_merged_*` Markdown it was computed from.
+- Download: `GET /reference/referencefile/download_file/{referencefile_id}`
+  (already wrapped by `get_file_from_abc_reffile_obj`).
+- FB training-set references are already embedded (SCRUM-6144 Done).
+
+## Decisions (confirmed with PO)
+
+1. **Feature = mean of the paragraph-level embeddings** in the main-PDF parquet
+   (rows with `is_document_level == False`), producing one 1536-d vector per
+   reference. The document-level row is ignored.
+2. **Main PDF only:** select the embedding whose `source.file_class ==
+   "converted_merged_main"`. Supplement embeddings are ignored.
+3. **Retrocompat via a per-model marker** (not a global date cutoff): the trainer
+   stamps a machine-readable marker into the model's ABC `ml_model.description`.
+   The classifier reads it per model — marker present ⇒ ABC-embedding path; absent
+   ⇒ the existing BioWordVec on-the-fly path, byte-for-byte unchanged. This needs
+   **no ABC schema change**: the `description` column already exists, the
+   `/ml_model/upload` endpoint already accepts it, and `get_model_data` already
+   returns it.
+4. **Scope of retraining:** all FB document-classification topics that have a
+   training dataset on the target ABC, plus the "no genetic data" classifier
+   (FB `ATP:0000207`). Upload to dev/stage with `production=false`.
+
+## Components
+
+### New: `utils/abc_embeddings.py`
+Single source of truth for the profile constants + marker format + parquet read.
+
+- Constants: `ABC_EMBEDDING_PROFILE`, `ABC_EMBEDDING_VERSION`,
+  `ABC_EMBEDDING_MODEL`, `ABC_EMBEDDING_DIM`, `ABC_EMBEDDING_POOLING="paragraph_mean"`.
+- `format_embedding_marker(...) -> str` / `parse_embedding_marker(description) -> dict|None`:
+  a sentinel-prefixed `key=value` marker, tolerant parsing. Detection is by the
+  sentinel token; absence ⇒ `None`.
+- `paragraph_mean_from_parquet(parquet_bytes) -> np.ndarray|None`: read the parquet
+  from bytes with `pyarrow`, average the `embedding` of rows where
+  `is_document_level` is false. `None` when there are no paragraph rows.
+
+### `utils/abc_utils.py`
+- `get_reference_embedding(reference_curie, mod_abbreviation, profile_name, version) -> np.ndarray|None`:
+  `show_all` → pick the `embedding` row with the matching `profile_name`/`version`
+  whose `source.file_class == "converted_merged_main"` → download parquet →
+  `paragraph_mean_from_parquet`. `None` when the reference has no such embedding.
+- `upload_ml_model(...)`: add an optional `description` parameter, sent as a form
+  field in the upload payload.
+
+### Trainer `agr_document_classifier_trainer.py`
+- New flag `--use_abc_embeddings`. When set:
+  - `--embedding_model_path` is not required (no BioWordVec load).
+  - Build `X` from the ABC paragraph-mean vector of each positive/negative curie
+    (references with no embedding are dropped and logged — same policy as a
+    missing MD today). No MD download, no text pipeline, no BoW/max/LSH blocks.
+  - Stamp the marker into `description` and pass it to `upload_ml_model`.
+- The existing BioWordVec path is untouched when the flag is off.
+
+### Classifier `agr_document_classifier_classify.py`
+- Per model, after `get_model_data`, parse `description` for the marker.
+  - Marker present ⇒ for each reference in the batch fetch the ABC paragraph-mean
+    vector and predict on it; a reference with no embedding is treated as an
+    invalid embedding (job failed) exactly like a missing MD today.
+  - Marker absent ⇒ current BioWordVec path, unchanged.
+- The BioWordVec embedding model is still loaded once for the mixed run; ABC-marked
+  models ignore it.
+
+## Data flow (ABC path)
+
+```
+curie ─ show_all ─▶ embedding row (profile match, source=converted_merged_main)
+      ─ download_file ─▶ parquet bytes
+      ─ paragraph_mean_from_parquet ─▶ 1536-d vector  ─▶ X row
+```
+
+## Dependencies
+- Add `pyarrow` to `requirements.txt` (parquet reader). No `openai`/`tiktoken`
+  needed on the consumer side (reading only). Install `pyarrow` in the cervino
+  conda env before training.
+
+## Testing
+- Unit tests with a synthetic parquet (pyarrow) and mocked `show_all`/download:
+  - `paragraph_mean_from_parquet` averages only paragraph rows; `None` on
+    doc-level-only.
+  - `get_reference_embedding` selects the `converted_merged_main` profile row and
+    ignores supplements / wrong profile / missing embedding.
+  - marker round-trip (`format`/`parse`), and absence ⇒ `None` (retrocompat gate).
+
+## Out of scope
+- WB retraining (SCRUM-5780), abstract embeddings, paragraph-level (non-pooled)
+  features, and any change to the ABC producer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,5 +81,6 @@ xmltodict==0.13.0
 pubmed_parser @ git+https://github.com/titipata/pubmed_parser
 retry==0.9.2
 matplotlib
+pyarrow==17.0.0
 agr-curation-api-client==0.12.0
 agr-abc-document-parsers==1.5.1

--- a/tests/utils/test_abc_embeddings.py
+++ b/tests/utils/test_abc_embeddings.py
@@ -20,27 +20,24 @@ def _parquet_bytes(rows):
     return buffer.getvalue()
 
 
-def test_marker_round_trip_without_bow():
-    parsed = abc_embeddings.parse_embedding_marker(abc_embeddings.format_embedding_marker())
-    assert parsed is not None
-    assert parsed["profile_name"] == abc_embeddings.ABC_EMBEDDING_PROFILE
-    assert parsed["version"] == abc_embeddings.ABC_EMBEDDING_VERSION
-    assert parsed["pooling"] == abc_embeddings.ABC_EMBEDDING_POOLING
-    assert parsed["bow"] is False
+def test_recipe_fields():
+    recipe = abc_embeddings.abc_embedding_recipe(use_bow=True)
+    assert recipe["embedding_profile"] == abc_embeddings.ABC_EMBEDDING_PROFILE
+    assert recipe["embedding_version"] == abc_embeddings.ABC_EMBEDDING_VERSION
+    assert recipe["embedding_model"] == abc_embeddings.ABC_EMBEDDING_MODEL
+    assert recipe["embedding_dim"] == abc_embeddings.ABC_EMBEDDING_DIM
+    assert recipe["embedding_pooling"] == abc_embeddings.ABC_EMBEDDING_POOLING
+    assert recipe["use_bow_features"] is True
+    assert abc_embeddings.abc_embedding_recipe(use_bow=False)["use_bow_features"] is False
 
 
-def test_marker_round_trip_with_bow():
-    parsed = abc_embeddings.parse_embedding_marker(
-        abc_embeddings.format_embedding_marker(use_bow=True))
-    assert parsed is not None
-    assert parsed["bow"] is True
-
-
-def test_marker_absent_returns_none():
-    # Legacy (BioWordVec) models have no marker: description is None or unrelated.
-    assert abc_embeddings.parse_embedding_marker(None) is None
-    assert abc_embeddings.parse_embedding_marker("") is None
-    assert abc_embeddings.parse_embedding_marker("some free-form description") is None
+def test_is_abc_embedding_model():
+    # ABC-embedding model: embedding_profile is set.
+    assert abc_embeddings.is_abc_embedding_model({"embedding_profile": abc_embeddings.ABC_EMBEDDING_PROFILE})
+    # Legacy / unavailable: profile null or absent.
+    assert not abc_embeddings.is_abc_embedding_model({"embedding_profile": None})
+    assert not abc_embeddings.is_abc_embedding_model({})
+    assert not abc_embeddings.is_abc_embedding_model(None)
 
 
 def test_pool_is_l2_normalized_chunk_mean_and_excludes_document_level():

--- a/tests/utils/test_abc_embeddings.py
+++ b/tests/utils/test_abc_embeddings.py
@@ -21,14 +21,13 @@ def _parquet_bytes(rows):
 
 
 def test_recipe_fields():
-    recipe = abc_embeddings.abc_embedding_recipe(use_bow=True)
-    assert recipe["embedding_profile"] == abc_embeddings.ABC_EMBEDDING_PROFILE
-    assert recipe["embedding_version"] == abc_embeddings.ABC_EMBEDDING_VERSION
-    assert recipe["embedding_model"] == abc_embeddings.ABC_EMBEDDING_MODEL
-    assert recipe["embedding_dim"] == abc_embeddings.ABC_EMBEDDING_DIM
-    assert recipe["embedding_pooling"] == abc_embeddings.ABC_EMBEDDING_POOLING
-    assert recipe["use_bow_features"] is True
-    assert abc_embeddings.abc_embedding_recipe(use_bow=False)["use_bow_features"] is False
+    # Only (profile, version) are stored on the model; everything else is a fixed
+    # convention or read from the parquet.
+    recipe = abc_embeddings.abc_embedding_recipe()
+    assert recipe == {
+        "embedding_profile": abc_embeddings.ABC_EMBEDDING_PROFILE,
+        "embedding_version": abc_embeddings.ABC_EMBEDDING_VERSION,
+    }
 
 
 def test_is_abc_embedding_model():

--- a/tests/utils/test_abc_embeddings.py
+++ b/tests/utils/test_abc_embeddings.py
@@ -9,25 +9,31 @@ from utils import abc_embeddings
 
 def _parquet_bytes(rows):
     """Build a minimal ABC embedding parquet from ``rows`` of
-    ``(embedding_list, is_document_level)``."""
+    ``(embedding_list, is_document_level, content)``."""
     table = pa.table({
         "embedding": pa.array([r[0] for r in rows], type=pa.list_(pa.float32())),
         "is_document_level": pa.array([r[1] for r in rows], type=pa.bool_()),
+        "content": pa.array([r[2] for r in rows], type=pa.string()),
     })
     buffer = BytesIO()
     pq.write_table(table, buffer)
     return buffer.getvalue()
 
 
-def test_marker_round_trip():
-    marker = abc_embeddings.format_embedding_marker()
-    parsed = abc_embeddings.parse_embedding_marker(marker)
+def test_marker_round_trip_without_bow():
+    parsed = abc_embeddings.parse_embedding_marker(abc_embeddings.format_embedding_marker())
     assert parsed is not None
     assert parsed["profile_name"] == abc_embeddings.ABC_EMBEDDING_PROFILE
     assert parsed["version"] == abc_embeddings.ABC_EMBEDDING_VERSION
-    assert parsed["model"] == abc_embeddings.ABC_EMBEDDING_MODEL
-    assert parsed["dim"] == abc_embeddings.ABC_EMBEDDING_DIM
     assert parsed["pooling"] == abc_embeddings.ABC_EMBEDDING_POOLING
+    assert parsed["bow"] is False
+
+
+def test_marker_round_trip_with_bow():
+    parsed = abc_embeddings.parse_embedding_marker(
+        abc_embeddings.format_embedding_marker(use_bow=True))
+    assert parsed is not None
+    assert parsed["bow"] is True
 
 
 def test_marker_absent_returns_none():
@@ -37,28 +43,35 @@ def test_marker_absent_returns_none():
     assert abc_embeddings.parse_embedding_marker("some free-form description") is None
 
 
-def test_paragraph_mean_averages_only_paragraph_rows():
-    # Two paragraph rows + one document-level row; the doc-level row must be ignored.
+def test_pool_is_l2_normalized_chunk_mean_and_excludes_document_level():
+    # Two paragraph rows + one document-level row (must be excluded from both the
+    # pooled vector and the BoW text).
     parquet = _parquet_bytes([
-        ([0.0, 0.0], False),
-        ([2.0, 4.0], False),
-        ([100.0, 100.0], True),  # document-level: excluded
+        ([1.0, 0.0], False, "alpha beta"),
+        ([0.0, 1.0], False, "gamma"),
+        ([9.0, 9.0], True, "DOCLEVEL"),
     ])
-    mean = abc_embeddings.paragraph_mean_from_parquet(parquet)
-    assert mean is not None
-    np.testing.assert_allclose(mean, np.array([1.0, 2.0], dtype=np.float32))
-    assert mean.dtype == np.float32
+    result = abc_embeddings.paragraph_pool_and_text(parquet)
+    assert result is not None
+    pooled, text = result
+    # L2([1,0])=[1,0]; L2([0,1])=[0,1]; mean=[.5,.5]; L2(mean)=[0.7071,0.7071].
+    np.testing.assert_allclose(pooled, np.array([0.70710678, 0.70710678], dtype=np.float32), rtol=1e-5)
+    np.testing.assert_allclose(np.linalg.norm(pooled), 1.0, rtol=1e-5)
+    assert text == "alpha beta gamma"
+    assert pooled.dtype == np.float32
 
 
-def test_paragraph_mean_none_when_only_document_level():
-    parquet = _parquet_bytes([([5.0, 6.0], True)])
-    assert abc_embeddings.paragraph_mean_from_parquet(parquet) is None
+def test_pool_none_when_only_document_level():
+    parquet = _parquet_bytes([([5.0, 6.0], True, "x")])
+    assert abc_embeddings.paragraph_pool_and_text(parquet) is None
 
 
-def test_paragraph_mean_skips_null_embeddings():
+def test_pool_skips_null_embeddings_but_keeps_text():
     parquet = _parquet_bytes([
-        (None, False),
-        ([2.0, 2.0], False),
+        (None, False, "no-vector text"),
+        ([2.0, 0.0], False, "has vector"),
     ])
-    mean = abc_embeddings.paragraph_mean_from_parquet(parquet)
-    np.testing.assert_allclose(mean, np.array([2.0, 2.0], dtype=np.float32))
+    pooled, text = abc_embeddings.paragraph_pool_and_text(parquet)
+    # Only the one real vector contributes: L2([2,0]) = [1,0].
+    np.testing.assert_allclose(pooled, np.array([1.0, 0.0], dtype=np.float32), rtol=1e-5)
+    assert text == "no-vector text has vector"

--- a/tests/utils/test_abc_embeddings.py
+++ b/tests/utils/test_abc_embeddings.py
@@ -1,0 +1,64 @@
+from io import BytesIO
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from utils import abc_embeddings
+
+
+def _parquet_bytes(rows):
+    """Build a minimal ABC embedding parquet from ``rows`` of
+    ``(embedding_list, is_document_level)``."""
+    table = pa.table({
+        "embedding": pa.array([r[0] for r in rows], type=pa.list_(pa.float32())),
+        "is_document_level": pa.array([r[1] for r in rows], type=pa.bool_()),
+    })
+    buffer = BytesIO()
+    pq.write_table(table, buffer)
+    return buffer.getvalue()
+
+
+def test_marker_round_trip():
+    marker = abc_embeddings.format_embedding_marker()
+    parsed = abc_embeddings.parse_embedding_marker(marker)
+    assert parsed is not None
+    assert parsed["profile_name"] == abc_embeddings.ABC_EMBEDDING_PROFILE
+    assert parsed["version"] == abc_embeddings.ABC_EMBEDDING_VERSION
+    assert parsed["model"] == abc_embeddings.ABC_EMBEDDING_MODEL
+    assert parsed["dim"] == abc_embeddings.ABC_EMBEDDING_DIM
+    assert parsed["pooling"] == abc_embeddings.ABC_EMBEDDING_POOLING
+
+
+def test_marker_absent_returns_none():
+    # Legacy (BioWordVec) models have no marker: description is None or unrelated.
+    assert abc_embeddings.parse_embedding_marker(None) is None
+    assert abc_embeddings.parse_embedding_marker("") is None
+    assert abc_embeddings.parse_embedding_marker("some free-form description") is None
+
+
+def test_paragraph_mean_averages_only_paragraph_rows():
+    # Two paragraph rows + one document-level row; the doc-level row must be ignored.
+    parquet = _parquet_bytes([
+        ([0.0, 0.0], False),
+        ([2.0, 4.0], False),
+        ([100.0, 100.0], True),  # document-level: excluded
+    ])
+    mean = abc_embeddings.paragraph_mean_from_parquet(parquet)
+    assert mean is not None
+    np.testing.assert_allclose(mean, np.array([1.0, 2.0], dtype=np.float32))
+    assert mean.dtype == np.float32
+
+
+def test_paragraph_mean_none_when_only_document_level():
+    parquet = _parquet_bytes([([5.0, 6.0], True)])
+    assert abc_embeddings.paragraph_mean_from_parquet(parquet) is None
+
+
+def test_paragraph_mean_skips_null_embeddings():
+    parquet = _parquet_bytes([
+        (None, False),
+        ([2.0, 2.0], False),
+    ])
+    mean = abc_embeddings.paragraph_mean_from_parquet(parquet)
+    np.testing.assert_allclose(mean, np.array([2.0, 2.0], dtype=np.float32))

--- a/tests/utils/test_get_reference_embedding.py
+++ b/tests/utils/test_get_reference_embedding.py
@@ -17,10 +17,11 @@ def _embedding_row(referencefile_id, profile, version, source_file_class):
     }
 
 
-@patch("utils.abc_utils.paragraph_mean_from_parquet", return_value=np.array([1.0, 2.0], dtype=np.float32))
+@patch("utils.abc_utils.paragraph_pool_and_text",
+       return_value=(np.array([1.0, 2.0], dtype=np.float32), "doc text"))
 @patch("utils.abc_utils.get_file_from_abc_reffile_obj", return_value=b"parquet-bytes")
 @patch("utils.abc_utils._show_all_for_reference")
-def test_selects_main_source_matching_profile(mock_show_all, mock_download, mock_mean):
+def test_selects_main_source_matching_profile(mock_show_all, mock_download, mock_pool):
     mock_show_all.return_value = [
         # supplement-source embedding of the right profile → must be ignored
         _embedding_row(1, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_supplement"),
@@ -29,8 +30,9 @@ def test_selects_main_source_matching_profile(mock_show_all, mock_download, mock
         # right profile + main source → the one to use
         _embedding_row(3, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_main"),
     ]
-    vec = abc_utils.get_reference_embedding("AGRKB:1", "FB")
-    np.testing.assert_allclose(vec, np.array([1.0, 2.0], dtype=np.float32))
+    pooled, text = abc_utils.get_reference_embedding("AGRKB:1", "FB")
+    np.testing.assert_allclose(pooled, np.array([1.0, 2.0], dtype=np.float32))
+    assert text == "doc text"
     # It downloaded the main-source row (id 3), not the supplement or wrong-profile ones.
     assert mock_download.call_args[0][0]["referencefile_id"] == 3
 
@@ -61,12 +63,12 @@ def test_none_when_show_all_fails(_mock_show_all):
     assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
 
 
-@patch("utils.abc_utils.paragraph_mean_from_parquet")
+@patch("utils.abc_utils.paragraph_pool_and_text")
 @patch("utils.abc_utils.get_file_from_abc_reffile_obj", return_value=b"")
 @patch("utils.abc_utils._show_all_for_reference")
-def test_none_when_download_empty(mock_show_all, _mock_download, mock_mean):
+def test_none_when_download_empty(mock_show_all, _mock_download, mock_pool):
     mock_show_all.return_value = [
         _embedding_row(3, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_main"),
     ]
     assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
-    mock_mean.assert_not_called()
+    mock_pool.assert_not_called()

--- a/tests/utils/test_get_reference_embedding.py
+++ b/tests/utils/test_get_reference_embedding.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+import numpy as np
+
+from utils import abc_utils
+from utils.abc_embeddings import ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION
+
+
+def _embedding_row(referencefile_id, profile, version, source_file_class):
+    return {
+        "file_class": "embedding",
+        "file_extension": "parquet",
+        "referencefile_id": referencefile_id,
+        "profile_name": profile,
+        "version": version,
+        "source": {"file_class": source_file_class} if source_file_class else None,
+    }
+
+
+@patch("utils.abc_utils.paragraph_mean_from_parquet", return_value=np.array([1.0, 2.0], dtype=np.float32))
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj", return_value=b"parquet-bytes")
+@patch("utils.abc_utils._show_all_for_reference")
+def test_selects_main_source_matching_profile(mock_show_all, mock_download, mock_mean):
+    mock_show_all.return_value = [
+        # supplement-source embedding of the right profile → must be ignored
+        _embedding_row(1, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_supplement"),
+        # wrong profile, main source → must be ignored
+        _embedding_row(2, "some_other_profile", ABC_EMBEDDING_VERSION, "converted_merged_main"),
+        # right profile + main source → the one to use
+        _embedding_row(3, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_main"),
+    ]
+    vec = abc_utils.get_reference_embedding("AGRKB:1", "FB")
+    np.testing.assert_allclose(vec, np.array([1.0, 2.0], dtype=np.float32))
+    # It downloaded the main-source row (id 3), not the supplement or wrong-profile ones.
+    assert mock_download.call_args[0][0]["referencefile_id"] == 3
+
+
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+@patch("utils.abc_utils._show_all_for_reference")
+def test_none_when_no_main_source_embedding(mock_show_all, mock_download):
+    mock_show_all.return_value = [
+        _embedding_row(1, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_supplement"),
+        {"file_class": "main", "file_extension": "pdf", "referencefile_id": 9},
+    ]
+    assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
+    mock_download.assert_not_called()
+
+
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj")
+@patch("utils.abc_utils._show_all_for_reference")
+def test_none_when_wrong_version(mock_show_all, mock_download):
+    mock_show_all.return_value = [
+        _embedding_row(1, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION + 1, "converted_merged_main"),
+    ]
+    assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
+    mock_download.assert_not_called()
+
+
+@patch("utils.abc_utils._show_all_for_reference", return_value=None)
+def test_none_when_show_all_fails(_mock_show_all):
+    assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
+
+
+@patch("utils.abc_utils.paragraph_mean_from_parquet")
+@patch("utils.abc_utils.get_file_from_abc_reffile_obj", return_value=b"")
+@patch("utils.abc_utils._show_all_for_reference")
+def test_none_when_download_empty(mock_show_all, _mock_download, mock_mean):
+    mock_show_all.return_value = [
+        _embedding_row(3, ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION, "converted_merged_main"),
+    ]
+    assert abc_utils.get_reference_embedding("AGRKB:1", "FB") is None
+    mock_mean.assert_not_called()

--- a/tests/utils/test_upload_ml_model_server.py
+++ b/tests/utils/test_upload_ml_model_server.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from utils import abc_utils
+
+_STATS = {"model_name": "XGBClassifier", "average_precision": 0.9,
+          "average_recall": 0.8, "average_f1": 0.85, "best_params": {"a": 1}}
+
+
+def _run_upload(monkeypatch_env):
+    with tempfile.TemporaryDirectory() as tmp:
+        model_path = os.path.join(tmp, "FB_ATP_0000207_classifier.joblib")
+        with open(model_path, "wb") as handle:
+            handle.write(b"model-bytes")
+        resp = MagicMock(status_code=201)
+        with patch("utils.abc_utils.get_authentication_token", return_value="t"), \
+                patch("utils.abc_utils.generate_headers", return_value={"Content-Type": "application/json"}), \
+                patch("utils.abc_utils.requests.post", return_value=resp) as mock_post:
+            for key, value in monkeypatch_env.items():
+                os.environ[key] = value
+            try:
+                abc_utils.upload_ml_model(
+                    task_type="biocuration_topic_classification", mod_abbreviation="FB",
+                    topic="ATP:0000207", model_path=model_path, stats=_STATS, dataset_id=39,
+                    file_extension="joblib", production=False, description="[abc_embeddings]")
+            finally:
+                for key in monkeypatch_env:
+                    os.environ.pop(key, None)
+        return mock_post.call_args[0][0], mock_post.call_args
+
+
+def test_upload_url_uses_override_when_set():
+    url, call = _run_upload({"ABC_UPLOAD_API_SERVER": "https://stage-literature-rest.alliancegenome.org"})
+    assert url == "https://stage-literature-rest.alliancegenome.org/ml_model/upload"
+    # description carrying the marker is sent in the form data
+    assert call.kwargs["data"]["description"] == "[abc_embeddings]"
+
+
+def test_upload_url_defaults_to_blue_api_when_unset():
+    url, _ = _run_upload({})
+    assert url == f"{abc_utils.blue_api_base_url}/ml_model/upload"

--- a/tests/utils/test_upload_ml_model_server.py
+++ b/tests/utils/test_upload_ml_model_server.py
@@ -23,7 +23,8 @@ def _run_upload(monkeypatch_env):
                 abc_utils.upload_ml_model(
                     task_type="biocuration_topic_classification", mod_abbreviation="FB",
                     topic="ATP:0000207", model_path=model_path, stats=_STATS, dataset_id=39,
-                    file_extension="joblib", production=False, description="[abc_embeddings]")
+                    file_extension="joblib", production=False,
+                    embedding_recipe={"embedding_profile": "prof", "use_bow_features": True})
             finally:
                 for key in monkeypatch_env:
                     os.environ.pop(key, None)
@@ -33,8 +34,9 @@ def _run_upload(monkeypatch_env):
 def test_upload_url_uses_override_when_set():
     url, call = _run_upload({"ABC_UPLOAD_API_SERVER": "https://stage-literature-rest.alliancegenome.org"})
     assert url == "https://stage-literature-rest.alliancegenome.org/ml_model/upload"
-    # description carrying the marker is sent in the form data
-    assert call.kwargs["data"]["description"] == "[abc_embeddings]"
+    # the embedding recipe is sent as dedicated form fields
+    assert call.kwargs["data"]["embedding_profile"] == "prof"
+    assert call.kwargs["data"]["use_bow_features"] is True
 
 
 def test_upload_url_defaults_to_blue_api_when_unset():

--- a/tests/utils/test_upload_ml_model_server.py
+++ b/tests/utils/test_upload_ml_model_server.py
@@ -24,7 +24,7 @@ def _run_upload(monkeypatch_env):
                     task_type="biocuration_topic_classification", mod_abbreviation="FB",
                     topic="ATP:0000207", model_path=model_path, stats=_STATS, dataset_id=39,
                     file_extension="joblib", production=False,
-                    embedding_recipe={"embedding_profile": "prof", "use_bow_features": True})
+                    embedding_recipe={"embedding_profile": "prof", "embedding_version": 1})
             finally:
                 for key in monkeypatch_env:
                     os.environ.pop(key, None)
@@ -36,7 +36,7 @@ def test_upload_url_uses_override_when_set():
     assert url == "https://stage-literature-rest.alliancegenome.org/ml_model/upload"
     # the embedding recipe is sent as dedicated form fields
     assert call.kwargs["data"]["embedding_profile"] == "prof"
-    assert call.kwargs["data"]["use_bow_features"] is True
+    assert call.kwargs["data"]["embedding_version"] == 1
 
 
 def test_upload_url_defaults_to_blue_api_when_unset():

--- a/utils/abc_embeddings.py
+++ b/utils/abc_embeddings.py
@@ -54,13 +54,11 @@ _EMBEDDING_COLUMN = "embedding"
 _IS_DOCUMENT_LEVEL_COLUMN = "is_document_level"
 _CONTENT_COLUMN = "content"
 
-# Marker written into ``ml_model.description`` at train time and parsed at
-# classify time. Its presence is the retrocompat switch: a model whose metadata
-# carries the marker consumes ABC embeddings; a model without it (every model
-# trained before this change) keeps using the on-the-fly BioWordVec path. The
-# ``bow`` field records whether the hashed BoW block was concatenated, so classify
-# reconstructs the exact same feature vector without relying on CLI flags.
-_MARKER_SENTINEL = "[abc_embeddings]"
+# The ABC-embedding recipe is stored on the model as dedicated ``ml_model``
+# columns (SCRUM-5781), NOT overloaded into description/parameters. A model with
+# ``embedding_profile`` set was trained on ABC embeddings and the classifier
+# rebuilds the matching feature vector; a model with it NULL/absent (every model
+# trained before this change) keeps the on-the-fly BioWordVec path.
 
 
 def _l2(vector: np.ndarray) -> np.ndarray:
@@ -69,52 +67,24 @@ def _l2(vector: np.ndarray) -> np.ndarray:
     return vector / norm if norm > 0 else vector
 
 
-def format_embedding_marker(profile_name: str = ABC_EMBEDDING_PROFILE,
-                            version: int = ABC_EMBEDDING_VERSION,
-                            model: str = ABC_EMBEDDING_MODEL,
-                            dim: int = ABC_EMBEDDING_DIM,
-                            pooling: str = ABC_EMBEDDING_POOLING,
-                            use_bow: bool = False) -> str:
-    """Build the ``ml_model.description`` marker recording that a model was trained
-    on ABC embeddings and with which recipe (including whether BoW was used)."""
-    return (f"{_MARKER_SENTINEL} profile={profile_name} version={version} "
-            f"model={model} dim={dim} pooling={pooling} "
-            f"bow={'true' if use_bow else 'false'}")
-
-
-def parse_embedding_marker(description: Optional[str]) -> Optional[dict]:
-    """Parse an ABC-embedding marker out of a model's ``description``.
-
-    Returns a dict with ``profile_name``/``version``/``model``/``dim``/``pooling``/
-    ``bow`` when the marker is present, or ``None`` otherwise (i.e. a legacy
-    BioWordVec model). Parsing is tolerant: unknown/malformed tokens are ignored
-    and only the sentinel is required.
-    """
-    if not description or _MARKER_SENTINEL not in description:
-        return None
-    tail = description.split(_MARKER_SENTINEL, 1)[1]
-    parsed = {
-        "profile_name": ABC_EMBEDDING_PROFILE,
-        "version": ABC_EMBEDDING_VERSION,
-        "model": ABC_EMBEDDING_MODEL,
-        "dim": ABC_EMBEDDING_DIM,
-        "pooling": ABC_EMBEDDING_POOLING,
-        "bow": False,
+def abc_embedding_recipe(use_bow: bool = True) -> dict:
+    """The ABC-embedding recipe fields to store on the model at train time
+    (the ``ml_model`` embedding_* columns + ``use_bow_features``), so the
+    classifier can rebuild the identical feature vector."""
+    return {
+        "embedding_profile": ABC_EMBEDDING_PROFILE,
+        "embedding_version": ABC_EMBEDDING_VERSION,
+        "embedding_model": ABC_EMBEDDING_MODEL,
+        "embedding_dim": ABC_EMBEDDING_DIM,
+        "embedding_pooling": ABC_EMBEDDING_POOLING,
+        "use_bow_features": use_bow,
     }
-    for token in tail.split():
-        if "=" not in token:
-            continue
-        key, value = token.split("=", 1)
-        if key in ("version", "dim"):
-            try:
-                parsed[key] = int(value)
-            except ValueError:
-                logger.warning("Ignoring non-integer %s in embedding marker: %r", key, value)
-        elif key == "bow":
-            parsed["bow"] = value.strip().lower() == "true"
-        elif key in ("profile_name", "model", "pooling"):
-            parsed[key] = value
-    return parsed
+
+
+def is_abc_embedding_model(model_meta_data: Optional[dict]) -> bool:
+    """True if the model's metadata marks it as trained on ABC embeddings
+    (``embedding_profile`` set); legacy BioWordVec models have it NULL/absent."""
+    return bool((model_meta_data or {}).get("embedding_profile"))
 
 
 def paragraph_pool_and_text(parquet_bytes: bytes) -> Optional[Tuple[np.ndarray, str]]:

--- a/utils/abc_embeddings.py
+++ b/utils/abc_embeddings.py
@@ -8,10 +8,17 @@ registers it as a ``referencefile`` with ``file_class == "embedding"`` (producer
     classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned  (version 1,
     model text-embedding-3-small, 1536-d)
 
-This module is the single source of truth for that profile, for the classifier's
-feature recipe (mean of the paragraph-level chunk embeddings), and for the
-per-model marker that lets the classifier tell a new ABC-embedding model apart
-from a legacy BioWordVec model without any ABC schema change.
+Feature recipe (validated in SCRUM-6052, ``local_tests/openai_embed_test``): the
+dense block is the **L2-normalized chunk-mean pool** of the main-PDF paragraph
+embeddings — each paragraph vector L2-normalized, averaged, and the mean
+L2-normalized again — optionally concatenated with the same stateless hashed
+bag-of-words block the BioWordVec classifiers use. In that analysis the embedding
+alone underperformed BoW, while embedding+BoW matched the BoW baseline, so the
+production models pair the two.
+
+This module is the single source of truth for the profile, the pooling recipe,
+the BoW text source, and the per-model marker that lets the classifier tell a new
+ABC-embedding model apart from a legacy BioWordVec model with no ABC schema change.
 
 Only the reading side lives here (``pyarrow``); nothing in this repo generates
 embeddings, so ``openai``/``tiktoken`` are not needed.
@@ -19,7 +26,7 @@ embeddings, so ``openai``/``tiktoken`` are not needed.
 
 import logging
 from io import BytesIO
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -32,9 +39,10 @@ ABC_EMBEDDING_PROFILE = "classifier_fulltext_paragraph_chunk_refs_excluded_md_cl
 ABC_EMBEDDING_VERSION = 1
 ABC_EMBEDDING_MODEL = "text-embedding-3-small"
 ABC_EMBEDDING_DIM = 1536
-# How the per-reference feature vector is built from the parquet: the arithmetic
-# mean of the paragraph-level chunk embeddings (the document-level row is ignored).
-ABC_EMBEDDING_POOLING = "paragraph_mean"
+# How the dense per-reference vector is built: L2-normalize each paragraph
+# embedding, average them, and L2-normalize the mean (SCRUM-6052 recipe). The
+# document-level parquet row is ignored.
+ABC_EMBEDDING_POOLING = "l2_chunk_mean"
 
 # The merged-Markdown source a classifier embedding must come from: the main PDF's
 # converted text (supplements produce their own embedding files, which we ignore).
@@ -44,32 +52,43 @@ MAIN_SOURCE_FILE_CLASS = "converted_merged_main"
 # ``agr_abc_document_parsers.embeddings.parquet_io``).
 _EMBEDDING_COLUMN = "embedding"
 _IS_DOCUMENT_LEVEL_COLUMN = "is_document_level"
+_CONTENT_COLUMN = "content"
 
 # Marker written into ``ml_model.description`` at train time and parsed at
 # classify time. Its presence is the retrocompat switch: a model whose metadata
 # carries the marker consumes ABC embeddings; a model without it (every model
-# trained before this change) keeps using the on-the-fly BioWordVec path.
+# trained before this change) keeps using the on-the-fly BioWordVec path. The
+# ``bow`` field records whether the hashed BoW block was concatenated, so classify
+# reconstructs the exact same feature vector without relying on CLI flags.
 _MARKER_SENTINEL = "[abc_embeddings]"
+
+
+def _l2(vector: np.ndarray) -> np.ndarray:
+    """Return ``vector`` L2-normalized (unchanged when its norm is 0)."""
+    norm = np.linalg.norm(vector)
+    return vector / norm if norm > 0 else vector
 
 
 def format_embedding_marker(profile_name: str = ABC_EMBEDDING_PROFILE,
                             version: int = ABC_EMBEDDING_VERSION,
                             model: str = ABC_EMBEDDING_MODEL,
                             dim: int = ABC_EMBEDDING_DIM,
-                            pooling: str = ABC_EMBEDDING_POOLING) -> str:
+                            pooling: str = ABC_EMBEDDING_POOLING,
+                            use_bow: bool = False) -> str:
     """Build the ``ml_model.description`` marker recording that a model was trained
-    on ABC embeddings and with which recipe."""
+    on ABC embeddings and with which recipe (including whether BoW was used)."""
     return (f"{_MARKER_SENTINEL} profile={profile_name} version={version} "
-            f"model={model} dim={dim} pooling={pooling}")
+            f"model={model} dim={dim} pooling={pooling} "
+            f"bow={'true' if use_bow else 'false'}")
 
 
 def parse_embedding_marker(description: Optional[str]) -> Optional[dict]:
     """Parse an ABC-embedding marker out of a model's ``description``.
 
-    Returns a dict with ``profile_name``/``version``/``model``/``dim``/``pooling``
-    when the marker is present, or ``None`` otherwise (i.e. a legacy BioWordVec
-    model). Parsing is tolerant: unknown/malformed tokens are ignored and only the
-    sentinel is required.
+    Returns a dict with ``profile_name``/``version``/``model``/``dim``/``pooling``/
+    ``bow`` when the marker is present, or ``None`` otherwise (i.e. a legacy
+    BioWordVec model). Parsing is tolerant: unknown/malformed tokens are ignored
+    and only the sentinel is required.
     """
     if not description or _MARKER_SENTINEL not in description:
         return None
@@ -80,40 +99,53 @@ def parse_embedding_marker(description: Optional[str]) -> Optional[dict]:
         "model": ABC_EMBEDDING_MODEL,
         "dim": ABC_EMBEDDING_DIM,
         "pooling": ABC_EMBEDDING_POOLING,
+        "bow": False,
     }
     for token in tail.split():
         if "=" not in token:
             continue
         key, value = token.split("=", 1)
-        if key == "version" or key == "dim":
+        if key in ("version", "dim"):
             try:
                 parsed[key] = int(value)
             except ValueError:
                 logger.warning("Ignoring non-integer %s in embedding marker: %r", key, value)
+        elif key == "bow":
+            parsed["bow"] = value.strip().lower() == "true"
         elif key in ("profile_name", "model", "pooling"):
             parsed[key] = value
     return parsed
 
 
-def paragraph_mean_from_parquet(parquet_bytes: bytes) -> Optional[np.ndarray]:
-    """Return the mean of the paragraph-level chunk embeddings in an ABC embedding
-    parquet, as a float32 vector, or ``None`` when there are no paragraph rows.
+def paragraph_pool_and_text(parquet_bytes: bytes) -> Optional[Tuple[np.ndarray, str]]:
+    """Return ``(pooled_vector, paragraph_text)`` for an ABC embedding parquet, or
+    ``None`` when it has no paragraph rows.
 
-    Paragraph rows are those with ``is_document_level`` false; the single
-    document-level row (the whole-document vector the producer also stores) is
-    deliberately excluded so the feature is exactly the average of the paragraphs.
+    ``pooled_vector`` is the L2-normalized mean of the L2-normalized paragraph
+    embeddings (the document-level row is excluded). ``paragraph_text`` is the
+    concatenation of the paragraph chunks' ``content`` — the (references-excluded)
+    document text used to build the hashed BoW block, so a consumer needs only the
+    parquet, no extra Markdown download.
     """
     import pyarrow.parquet as pq
 
-    table = pq.read_table(BytesIO(parquet_bytes),
-                          columns=[_EMBEDDING_COLUMN, _IS_DOCUMENT_LEVEL_COLUMN])
+    table = pq.read_table(
+        BytesIO(parquet_bytes),
+        columns=[_EMBEDDING_COLUMN, _IS_DOCUMENT_LEVEL_COLUMN, _CONTENT_COLUMN])
     is_document_level = table.column(_IS_DOCUMENT_LEVEL_COLUMN).to_pylist()
     embeddings = table.column(_EMBEDDING_COLUMN).to_pylist()
+    contents = table.column(_CONTENT_COLUMN).to_pylist()
 
-    paragraph_vectors = [
-        vector for vector, is_doc in zip(embeddings, is_document_level)
-        if not is_doc and vector is not None
-    ]
-    if not paragraph_vectors:
+    chunk_vectors = []
+    chunk_texts = []
+    for embedding, is_doc, content in zip(embeddings, is_document_level, contents):
+        if is_doc:
+            continue
+        if embedding is not None:
+            chunk_vectors.append(_l2(np.asarray(embedding, dtype=np.float32)))
+        if content:
+            chunk_texts.append(content)
+    if not chunk_vectors:
         return None
-    return np.mean(np.asarray(paragraph_vectors, dtype=np.float32), axis=0)
+    pooled = _l2(np.mean(chunk_vectors, axis=0)).astype(np.float32)
+    return pooled, " ".join(chunk_texts)

--- a/utils/abc_embeddings.py
+++ b/utils/abc_embeddings.py
@@ -1,0 +1,119 @@
+"""Consume the ABC's precomputed reference embeddings in the document classifier
+(SCRUM-5781).
+
+The ABC generates one embedding parquet per merged Markdown of a reference and
+registers it as a ``referencefile`` with ``file_class == "embedding"`` (producer:
+``agr_literature_service`` SCRUM-6141/6142). Exactly one profile exists today:
+
+    classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned  (version 1,
+    model text-embedding-3-small, 1536-d)
+
+This module is the single source of truth for that profile, for the classifier's
+feature recipe (mean of the paragraph-level chunk embeddings), and for the
+per-model marker that lets the classifier tell a new ABC-embedding model apart
+from a legacy BioWordVec model without any ABC schema change.
+
+Only the reading side lives here (``pyarrow``); nothing in this repo generates
+embeddings, so ``openai``/``tiktoken`` are not needed.
+"""
+
+import logging
+from io import BytesIO
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# --- The one existing ABC classifier-embedding profile (SCRUM-6142). Keep these
+# in one place: both train and classify import them so the feature recipe they
+# agree on can never drift. ---
+ABC_EMBEDDING_PROFILE = "classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned"
+ABC_EMBEDDING_VERSION = 1
+ABC_EMBEDDING_MODEL = "text-embedding-3-small"
+ABC_EMBEDDING_DIM = 1536
+# How the per-reference feature vector is built from the parquet: the arithmetic
+# mean of the paragraph-level chunk embeddings (the document-level row is ignored).
+ABC_EMBEDDING_POOLING = "paragraph_mean"
+
+# The merged-Markdown source a classifier embedding must come from: the main PDF's
+# converted text (supplements produce their own embedding files, which we ignore).
+MAIN_SOURCE_FILE_CLASS = "converted_merged_main"
+
+# Canonical parquet columns this module relies on (shared contract, see
+# ``agr_abc_document_parsers.embeddings.parquet_io``).
+_EMBEDDING_COLUMN = "embedding"
+_IS_DOCUMENT_LEVEL_COLUMN = "is_document_level"
+
+# Marker written into ``ml_model.description`` at train time and parsed at
+# classify time. Its presence is the retrocompat switch: a model whose metadata
+# carries the marker consumes ABC embeddings; a model without it (every model
+# trained before this change) keeps using the on-the-fly BioWordVec path.
+_MARKER_SENTINEL = "[abc_embeddings]"
+
+
+def format_embedding_marker(profile_name: str = ABC_EMBEDDING_PROFILE,
+                            version: int = ABC_EMBEDDING_VERSION,
+                            model: str = ABC_EMBEDDING_MODEL,
+                            dim: int = ABC_EMBEDDING_DIM,
+                            pooling: str = ABC_EMBEDDING_POOLING) -> str:
+    """Build the ``ml_model.description`` marker recording that a model was trained
+    on ABC embeddings and with which recipe."""
+    return (f"{_MARKER_SENTINEL} profile={profile_name} version={version} "
+            f"model={model} dim={dim} pooling={pooling}")
+
+
+def parse_embedding_marker(description: Optional[str]) -> Optional[dict]:
+    """Parse an ABC-embedding marker out of a model's ``description``.
+
+    Returns a dict with ``profile_name``/``version``/``model``/``dim``/``pooling``
+    when the marker is present, or ``None`` otherwise (i.e. a legacy BioWordVec
+    model). Parsing is tolerant: unknown/malformed tokens are ignored and only the
+    sentinel is required.
+    """
+    if not description or _MARKER_SENTINEL not in description:
+        return None
+    tail = description.split(_MARKER_SENTINEL, 1)[1]
+    parsed = {
+        "profile_name": ABC_EMBEDDING_PROFILE,
+        "version": ABC_EMBEDDING_VERSION,
+        "model": ABC_EMBEDDING_MODEL,
+        "dim": ABC_EMBEDDING_DIM,
+        "pooling": ABC_EMBEDDING_POOLING,
+    }
+    for token in tail.split():
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        if key == "version" or key == "dim":
+            try:
+                parsed[key] = int(value)
+            except ValueError:
+                logger.warning("Ignoring non-integer %s in embedding marker: %r", key, value)
+        elif key in ("profile_name", "model", "pooling"):
+            parsed[key] = value
+    return parsed
+
+
+def paragraph_mean_from_parquet(parquet_bytes: bytes) -> Optional[np.ndarray]:
+    """Return the mean of the paragraph-level chunk embeddings in an ABC embedding
+    parquet, as a float32 vector, or ``None`` when there are no paragraph rows.
+
+    Paragraph rows are those with ``is_document_level`` false; the single
+    document-level row (the whole-document vector the producer also stores) is
+    deliberately excluded so the feature is exactly the average of the paragraphs.
+    """
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(BytesIO(parquet_bytes),
+                          columns=[_EMBEDDING_COLUMN, _IS_DOCUMENT_LEVEL_COLUMN])
+    is_document_level = table.column(_IS_DOCUMENT_LEVEL_COLUMN).to_pylist()
+    embeddings = table.column(_EMBEDDING_COLUMN).to_pylist()
+
+    paragraph_vectors = [
+        vector for vector, is_doc in zip(embeddings, is_document_level)
+        if not is_doc and vector is not None
+    ]
+    if not paragraph_vectors:
+        return None
+    return np.mean(np.asarray(paragraph_vectors, dtype=np.float32), axis=0)

--- a/utils/abc_embeddings.py
+++ b/utils/abc_embeddings.py
@@ -67,17 +67,15 @@ def _l2(vector: np.ndarray) -> np.ndarray:
     return vector / norm if norm > 0 else vector
 
 
-def abc_embedding_recipe(use_bow: bool = True) -> dict:
-    """The ABC-embedding recipe fields to store on the model at train time
-    (the ``ml_model`` embedding_* columns + ``use_bow_features``), so the
-    classifier can rebuild the identical feature vector."""
+def abc_embedding_recipe() -> dict:
+    """The (profile, version) to store on the model at train time — the only pair
+    the classifier needs to select which stored embedding to fetch for a reference.
+    Pooling (L2 chunk-mean) and the BoW block are fixed conventions applied to every
+    ABC-embedding model, and model/dim are read from the parquet, so none of those
+    are stored on the model."""
     return {
         "embedding_profile": ABC_EMBEDDING_PROFILE,
         "embedding_version": ABC_EMBEDDING_VERSION,
-        "embedding_model": ABC_EMBEDDING_MODEL,
-        "embedding_dim": ABC_EMBEDDING_DIM,
-        "embedding_pooling": ABC_EMBEDDING_POOLING,
-        "use_bow_features": use_bow,
     }
 
 

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -1086,7 +1086,18 @@ def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: di
                     topic: str = None, file_extension: str = "", production: Union[bool, None] = False,
                     no_data: Union[bool, None] = True, species: Union[str, None] = None,
                     data_novelty: Union[str, None] = None, description: Union[str, None] = None,):
-    upload_url = f"{blue_api_base_url}/ml_model/upload"
+    # The model normally uploads to the same ABC as everything else
+    # (``blue_api_base_url``). ``ABC_UPLOAD_API_SERVER`` overrides only the upload
+    # target, so a run can read training data / embeddings from one environment
+    # (e.g. prod, where the embeddings live) and still upload the model to another
+    # (e.g. stage). dataset_id is shared across environments, so the uploaded
+    # metadata stays consistent.
+    upload_base = os.environ.get("ABC_UPLOAD_API_SERVER", "").strip() or blue_api_base_url
+    if upload_base.startswith("literature"):
+        upload_base = f"https://{upload_base}"
+    upload_url = f"{upload_base}/ml_model/upload"
+    if upload_base != blue_api_base_url:
+        logger.info(f"Uploading model to override server: {upload_base}")
     token = get_authentication_token()
     headers = generate_headers(token)
 

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -1087,7 +1087,7 @@ def download_abc_model(mod_abbreviation: str, task_type: str, output_path: str, 
 def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: dict, dataset_id: int = None,
                     topic: str = None, file_extension: str = "", production: Union[bool, None] = False,
                     no_data: Union[bool, None] = True, species: Union[str, None] = None,
-                    data_novelty: Union[str, None] = None, description: Union[str, None] = None,):
+                    data_novelty: Union[str, None] = None, embedding_recipe: Union[dict, None] = None,):
     # The model normally uploads to the same ABC as everything else
     # (``blue_api_base_url``). ``ABC_UPLOAD_API_SERVER`` overrides only the upload
     # target, so a run can read training data / embeddings from one environment
@@ -1121,11 +1121,11 @@ def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: di
         "data_novelty": data_novelty,
         "species": species
     }
-    # ``description`` carries the ABC-embedding marker (SCRUM-5781) so the
-    # classifier can tell an ABC-embedding model from a legacy BioWordVec one.
-    # Only send it when set, to leave legacy uploads byte-identical.
-    if description is not None:
-        metadata["description"] = description
+    # ABC-embedding recipe (SCRUM-5781): dedicated ml_model columns so the model
+    # self-describes its feature recipe. Only sent for ABC-embedding models; legacy
+    # uploads leave these columns NULL.
+    if embedding_recipe:
+        metadata.update(embedding_recipe)
 
     model_dir = os.path.dirname(model_path)
     if topic is None:

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -1095,7 +1095,10 @@ def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: di
     # (e.g. stage). dataset_id is shared across environments, so the uploaded
     # metadata stays consistent.
     upload_base = os.environ.get("ABC_UPLOAD_API_SERVER", "").strip() or blue_api_base_url
-    if upload_base.startswith("literature"):
+    # Accept a scheme-less host (e.g. "stage-literature-rest.alliancegenome.org")
+    # and default it to https, so any host works — not only ones starting with
+    # "literature". A value that already carries a scheme is left untouched.
+    if "://" not in upload_base:
         upload_base = f"https://{upload_base}"
     upload_url = f"{upload_base}/ml_model/upload"
     if upload_base != blue_api_base_url:

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -14,7 +14,7 @@ import psycopg2
 import requests
 from agr_cognito_py import get_authentication_token, generate_headers
 from utils.abc_embeddings import (ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION,
-                                  MAIN_SOURCE_FILE_CLASS, paragraph_mean_from_parquet)
+                                  MAIN_SOURCE_FILE_CLASS, paragraph_pool_and_text)
 from utils.ateam_utils import get_all_curated_entities as _get_all_curated_entities
 
 blue_api_base_url = os.environ.get('ABC_API_SERVER', "https://literature-rest.alliancegenome.org")
@@ -985,15 +985,17 @@ def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abb
 
 def get_reference_embedding(reference_curie: str, mod_abbreviation: str,
                             profile_name: str = ABC_EMBEDDING_PROFILE,
-                            version: int = ABC_EMBEDDING_VERSION) -> Optional[np.ndarray]:
-    """Return the ABC precomputed classifier embedding for a reference's MAIN PDF
-    text, as a single float32 vector, or ``None`` when it is unavailable.
+                            version: int = ABC_EMBEDDING_VERSION) -> Optional[Tuple[np.ndarray, str]]:
+    """Return ``(pooled_vector, paragraph_text)`` for a reference's MAIN-PDF ABC
+    embedding, or ``None`` when it is unavailable.
 
-    The vector is the mean of the paragraph-level chunk embeddings
-    (:func:`utils.abc_embeddings.paragraph_mean_from_parquet`) stored in the
-    embedding parquet whose profile is ``profile_name``/``version`` and whose
-    source Markdown is the ``converted_merged_main`` (SCRUM-6142). Supplement
-    embeddings and other profiles are ignored.
+    ``pooled_vector`` is the L2-normalized chunk-mean pool of the paragraph
+    embeddings and ``paragraph_text`` is the concatenated paragraph content (for
+    the hashed BoW block) — both from
+    :func:`utils.abc_embeddings.paragraph_pool_and_text`, read out of the embedding
+    parquet whose profile is ``profile_name``/``version`` and whose source Markdown
+    is the ``converted_merged_main`` (SCRUM-6142). Supplement embeddings and other
+    profiles are ignored.
 
     Discovery uses the existing ``show_all`` metadata (which annotates every
     ``embedding`` row with its ``profile_name``/``version`` and a ``source``
@@ -1030,7 +1032,7 @@ def get_reference_embedding(reference_curie: str, mod_abbreviation: str,
         logger.error("Embedding parquet download returned no bytes for %s", reference_curie)
         return None
     try:
-        return paragraph_mean_from_parquet(parquet_bytes)
+        return paragraph_pool_and_text(parquet_bytes)
     except Exception as e:
         logger.error("Failed to read embedding parquet for %s: %s", reference_curie, e)
         return None

--- a/utils/abc_utils.py
+++ b/utils/abc_utils.py
@@ -13,6 +13,8 @@ import numpy as np
 import psycopg2
 import requests
 from agr_cognito_py import get_authentication_token, generate_headers
+from utils.abc_embeddings import (ABC_EMBEDDING_PROFILE, ABC_EMBEDDING_VERSION,
+                                  MAIN_SOURCE_FILE_CLASS, paragraph_mean_from_parquet)
 from utils.ateam_utils import get_all_curated_entities as _get_all_curated_entities
 
 blue_api_base_url = os.environ.get('ABC_API_SERVER', "https://literature-rest.alliancegenome.org")
@@ -981,6 +983,59 @@ def _download_main_md_supplements(reference_curie: str, output_dir: str, mod_abb
             out_file.write(supp_bytes)
 
 
+def get_reference_embedding(reference_curie: str, mod_abbreviation: str,
+                            profile_name: str = ABC_EMBEDDING_PROFILE,
+                            version: int = ABC_EMBEDDING_VERSION) -> Optional[np.ndarray]:
+    """Return the ABC precomputed classifier embedding for a reference's MAIN PDF
+    text, as a single float32 vector, or ``None`` when it is unavailable.
+
+    The vector is the mean of the paragraph-level chunk embeddings
+    (:func:`utils.abc_embeddings.paragraph_mean_from_parquet`) stored in the
+    embedding parquet whose profile is ``profile_name``/``version`` and whose
+    source Markdown is the ``converted_merged_main`` (SCRUM-6142). Supplement
+    embeddings and other profiles are ignored.
+
+    Discovery uses the existing ``show_all`` metadata (which annotates every
+    ``embedding`` row with its ``profile_name``/``version`` and a ``source``
+    pointer) and the existing ``download_file`` fetch — MOD access on the parquet
+    is inherited from its source file, so no extra access handling is needed here.
+
+    ``None`` is returned (never raised) for every "not available" case — no
+    embedding row, an empty/broken parquet, or no paragraph rows — so callers can
+    treat it exactly like a missing MD file.
+    """
+    resp_obj = _show_all_for_reference(reference_curie)
+    if resp_obj is None:
+        return None
+
+    embedding_ref_file = None
+    for ref_file in resp_obj:
+        if ref_file.get("file_class") != "embedding":
+            continue
+        if ref_file.get("profile_name") != profile_name:
+            continue
+        if ref_file.get("version") != version:
+            continue
+        source = ref_file.get("source") or {}
+        if source.get("file_class") != MAIN_SOURCE_FILE_CLASS:
+            continue
+        embedding_ref_file = ref_file
+        break
+    if embedding_ref_file is None:
+        logger.debug("No %s embedding (main source) for %s", profile_name, reference_curie)
+        return None
+
+    parquet_bytes = get_file_from_abc_reffile_obj(embedding_ref_file)
+    if not parquet_bytes:
+        logger.error("Embedding parquet download returned no bytes for %s", reference_curie)
+        return None
+    try:
+        return paragraph_mean_from_parquet(parquet_bytes)
+    except Exception as e:
+        logger.error("Failed to read embedding parquet for %s: %s", reference_curie, e)
+        return None
+
+
 def get_model_data(mod_abbreviation: str, task_type: str, topic: str):
     model_data = None
     get_model_url = f"{blue_api_base_url}/ml_model/metadata/{task_type}/{mod_abbreviation}/{topic}"
@@ -1030,7 +1085,7 @@ def download_abc_model(mod_abbreviation: str, task_type: str, output_path: str, 
 def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: dict, dataset_id: int = None,
                     topic: str = None, file_extension: str = "", production: Union[bool, None] = False,
                     no_data: Union[bool, None] = True, species: Union[str, None] = None,
-                    data_novelty: Union[str, None] = None,):
+                    data_novelty: Union[str, None] = None, description: Union[str, None] = None,):
     upload_url = f"{blue_api_base_url}/ml_model/upload"
     token = get_authentication_token()
     headers = generate_headers(token)
@@ -1053,6 +1108,11 @@ def upload_ml_model(task_type: str, mod_abbreviation: str, model_path, stats: di
         "data_novelty": data_novelty,
         "species": species
     }
+    # ``description`` carries the ABC-embedding marker (SCRUM-5781) so the
+    # classifier can tell an ABC-embedding model from a legacy BioWordVec one.
+    # Only send it when set, to leave legacy uploads byte-identical.
+    if description is not None:
+        metadata["description"] = description
 
     model_dir = os.path.dirname(model_path)
     if topic is None:

--- a/utils/thread_limits.py
+++ b/utils/thread_limits.py
@@ -1,0 +1,19 @@
+"""Pin native BLAS/OpenMP libraries to a single thread (SCRUM-5781).
+
+Import this module **before** numpy / scikit-learn / LightGBM / XGBoost / pyarrow
+so the thread-count environment variables are read when those libraries load.
+
+Why: the classifier trainer reads the ABC embedding parquets with pyarrow, whose
+OpenMP runtime otherwise corrupts LightGBM's once ``RandomizedSearchCV`` forks
+``loky`` worker processes over the wide sparse BoW feature matrix — a worker dies
+with SIGSEGV (reproduced on cervino). Running one thread per fit, with search-level
+(loky) parallelism across candidates, avoids the crash at no real throughput cost.
+
+``setdefault`` is used so an explicit environment value still wins.
+"""
+
+import os
+
+for _thread_var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS",
+                    "NUMEXPR_NUM_THREADS"):
+    os.environ.setdefault(_thread_var, "1")


### PR DESCRIPTION
## Summary
Make the document classifier train + classify on the ABC's precomputed OpenAI embeddings (profile `classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned`, text-embedding-3-small, 1536-d) instead of computing BioWordVec on the fly, and retrain the FB classifiers on them. Backward-compatible: legacy models keep the BioWordVec path.

## What it does
- **New `utils/abc_embeddings.py`**: profile constants, `abc_embedding_recipe()`/`is_abc_embedding_model()`, and `paragraph_pool_and_text()` (reads the parquet, L2-normalized chunk-mean pool of the main-PDF paragraph embeddings + concatenated paragraph text for BoW).
- **`utils/abc_utils.get_reference_embedding()`**: discovers the main-PDF (`converted_merged_main`) embedding parquet for a reference via `show_all`, downloads it, returns `(pooled_vector, text)`.
- **Trainer**: ABC embeddings + hashed BoW are now the **default** training path (no `--use_abc_embeddings` flag); date filter defaults to 2005-01-01; no outlier removal. Stamps `(embedding_profile, embedding_version)` on the model.
- **Classifier**: routes per model on `is_abc_embedding_model()` (the `embedding_profile` column, set via the paired `agr_literature_service` PR #1245); ABC models pool from the parquet + BoW, legacy models unchanged.
- **`ABC_UPLOAD_API_SERVER`**: read embeddings from prod (only place they exist) while uploading models to stage.
- **Two segfault fixes** (pyarrow + LightGBM in loky workers on the wide sparse matrix): pin native threads to 1 (`utils/thread_limits`) and extend the `SEARCH_MAX_JOBS` worker cap to all models.
- `pyarrow` added to requirements; unit tests for pooling, parquet selection, recipe, and the upload override.

## Depends on
`agr_literature_service` PR #1245 (adds `ml_model.embedding_profile`/`embedding_version`). Deploy that + the classify code before promoting any ABC-embedding model to production.

## Result
All 5 FB classifiers retrained (LightGBM, holdout F1 0.83–0.89) and uploaded to stage with `production=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)