### PR TITLE
feat(SCRUM-6203): raise FB no-genetic-data positive threshold to 0.5

### DIFF
--- a/agr_document_classifier/agr_document_classifier_classify.py
+++ b/agr_document_classifier/agr_document_classifier_classify.py
@@ -31,6 +31,15 @@ from utils.slack_utils import send_slack_notification, format_skipped_jobs_html
 
 logger = logging.getLogger(__name__)
 
+# SCRUM-6203: an FB "no genetic data" (ATP:0000207) paper only gets the "manual indexing
+# status TBD" workflow tag (ATP:0000359) -- i.e. only surfaces for manual indexing -- when the
+# classifier's positive-class confidence is at least this threshold. Previously the tag was
+# created for every classified paper (an effective threshold of 0); it was raised now that a
+# weekly pipeline exports every manual_indexing_tag score to FB directly, so the low-confidence
+# papers no longer need surfacing. The manual_indexing_tag row itself is still written for every
+# paper regardless of confidence (the export consumes all of them).
+FB_NO_GENETIC_DATA_TBD_THRESHOLD = 0.5
+
 
 def configure_logging(log_level):
     # Configure logging based on the log_level argument
@@ -332,7 +341,7 @@ def process_job_batch(job_batch, mod_abbr, topic, tet_source_id, embedding_model
                         f"confidence_level: '{confidence_level}', tet_source_id: '{tet_source_id}' "
                         f"data_novelty: '{model_meta_data['data_novelty']}'")
         logger.info(f"Finished processing batch of {len(files_loaded)} jobs in test mode. Positive: "
-                    f"{sum(classifications)}. Negative: {len(classifications)-sum(classifications)}")
+                    f"{sum(classifications)}. Negative: {len(classifications) - sum(classifications)}")
     else:
         send_classification_results(files_loaded, classifications, conf_scores, valid_embeddings,
                                     reference_curie_job_map, mod_abbr, topic, tet_source_id, model_meta_data)
@@ -370,7 +379,13 @@ def send_classification_results(files_loaded, classifications, conf_scores, vali
             logger.debug(f"reference_curie: '{reference_curie}', species: '{species}', topic: '{topic}', confidence_level: '{confidence_level}', tet_source_id: '{tet_source_id}' data_novelty: '{model_meta_data['data_novelty']}")
             if send_to_manual_indexing:
                 result = send_manual_indexing_to_abc(reference_curie, mod_abbr, topic, conf_score)
-                if result and topic == 'ATP:0000207':  # set the wf to TBD only for FB no gen dta
+                # SCRUM-6203: only set the "manual indexing status TBD" workflow tag for FB
+                # "no genetic data" when the model is actually positive for the topic, i.e.
+                # confidence_score >= 0.5. The manual_indexing_tag above is still written for
+                # every paper (the weekly FB export consumes all scores).
+                if (result and topic == 'ATP:0000207'
+                        and conf_score is not None
+                        and conf_score >= FB_NO_GENETIC_DATA_TBD_THRESHOLD):
                     # Only create workflow tag if no manual indexing workflow tag exists
                     current_manual_indexing_status = get_current_workflow_status(
                         reference_curie, mod_abbr, "ATP:0000273")

--- a/tests/agr_document_classifier/test_no_genetic_data_threshold.py
+++ b/tests/agr_document_classifier/test_no_genetic_data_threshold.py
@@ -1,0 +1,53 @@
+"""SCRUM-6203: FB "no genetic data" (ATP:0000207) papers only get the
+"manual indexing status TBD" workflow tag (ATP:0000359) when the classifier's
+positive-class confidence is >= 0.5. A manual_indexing_tag is still written for
+every paper regardless of confidence (the weekly FB export consumes all scores).
+"""
+from unittest.mock import patch
+
+from agr_document_classifier import agr_document_classifier_classify as clf
+
+
+def _run(conf_scores, classifications):
+    curies = [f"AGRKB:10100000000000{i}" for i in range(len(conf_scores))]
+    files_loaded = [f"/tmp/{c.replace(':', '_')}.md" for c in curies]
+    valid_embeddings = [True] * len(conf_scores)
+    job_map = {c: {"job": i} for i, c in enumerate(curies)}
+    model_meta_data = {"negated": True, "data_novelty": "ATP:0000321",
+                       "species": None, "ml_model_id": 67}
+    with patch.object(clf, "send_manual_indexing_to_abc", return_value=True) as m_mi, \
+            patch.object(clf, "get_current_workflow_status", return_value=None), \
+            patch.object(clf, "create_workflow_tag") as m_ct, \
+            patch.object(clf, "set_job_success"), \
+            patch.object(clf, "set_job_started"), \
+            patch.object(clf, "set_job_failure"), \
+            patch.object(clf, "send_classification_tag_to_abc"):
+        clf.send_classification_results(
+            files_loaded, classifications, conf_scores, valid_embeddings, job_map,
+            "FB", "ATP:0000207", 1, model_meta_data)
+    return curies, m_mi, m_ct
+
+
+def test_tbd_tag_only_for_confidence_at_or_above_half():
+    curies, m_mi, m_ct = _run(conf_scores=[0.9, 0.3], classifications=[1, 0])
+    # manual_indexing_tag is written for EVERY paper (export needs all scores)
+    assert m_mi.call_count == 2
+    # TBD workflow tag created only for the >= 0.5 paper
+    assert m_ct.call_count == 1
+    _, kwargs = m_ct.call_args
+    assert kwargs["reference_curie"] == curies[0]
+    assert kwargs["workflow_tag_atp_id"] == "ATP:0000359"
+
+
+def test_tbd_tag_created_at_exactly_half():
+    # 0.5 counts as positive ("0.5 or more")
+    _, m_mi, m_ct = _run(conf_scores=[0.5], classifications=[1])
+    assert m_mi.call_count == 1
+    assert m_ct.call_count == 1
+
+
+def test_no_tbd_tag_below_half():
+    _, m_mi, m_ct = _run(conf_scores=[0.49], classifications=[0])
+    # still recorded for the export, but not surfaced for manual indexing
+    assert m_mi.call_count == 1
+    assert m_ct.call_count == 0


### PR DESCRIPTION
## What
Raises the FB "no genetic data" (ATP:0000207) positive threshold from an effective 0 to **0.5** in the classifier pipeline (SCRUM-6203).

`send_classification_results` now only creates the `ATP:0000359` "manual indexing status TBD" workflow tag when `confidence_score >= 0.5`. The `manual_indexing_tag` row is still written for **every** classified paper, so the weekly FB export still receives all scores.

## Why
The threshold was 0 so a curator could see all results; a weekly pipeline now exports every score to FB directly, so only genuine positives (≥ 0.5) should be surfaced for manual indexing. This needs to land **before** the retrained no-genetic-data model reaches production.

## Tests
- New `tests/agr_document_classifier/test_no_genetic_data_threshold.py`: TBD tag created only at ≥ 0.5 (including the 0.5 boundary), not below, while the `manual_indexing_tag` is written in all cases.
- flake8 clean; also fixes a pre-existing E226 in the touched function.

## Scope / follow-ups (not in this PR)
- **Facet count (point b of the ticket)** is an ABC change — the "manual indexing curation" facet counts `manual_indexing_tags.curation_tag` with no confidence filter, so it won't reflect the threshold automatically. Pending coordination with Ceri on SCRUM-6203.
- **Existing prod data cleanup**: strip the TBD tag from papers now scoring < 0.5 (preserving curator verdicts) — separate one-off script, pending Gillian's confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
