### PR TITLE
feat: Graylog logging via Docker gelf driver + agr.literature.automated_information_extraction.* image naming

### DIFF
--- a/.env
+++ b/.env
@@ -40,4 +40,4 @@ SLACK_CHANNEL_EMAIL=
 # Compose itself during interpolation, not by the container process.
 # ENV_STATE separates dev from prod streams in Graylog: dev, stage or prod.
 ENV_STATE=dev
-GELF_ADDRESS=udp://logs.alliancegenome.org:12201
+GELF_ADDRESS=udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201

--- a/.env.example
+++ b/.env.example
@@ -54,4 +54,4 @@ SLACK_CHANNEL_EMAIL=
 # Compose itself during interpolation, not by the container process.
 # ENV_STATE separates dev from prod streams in Graylog: dev, stage or prod.
 ENV_STATE=dev
-GELF_ADDRESS=udp://logs.alliancegenome.org:12201
+GELF_ADDRESS=udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Copy to .env and fill in the blanks:  cp .env.example .env
+
 TRAINING_DIR=/data/agr_document_classifier/training
 CLASSIFICATION_DIR=/data/agr_document_classifier/to_classify
 CLASSIFIERS_PATH=/data/agr_document_classifier
@@ -13,9 +15,15 @@ OKTA_API_AUDIENCE=api://default
 OKTA_CLIENT_ID=
 OKTA_CLIENT_SECRET=
 OKTA_DOMAIN=
+OKTA_AUTH_SERVER_ID=
+OKTA_AUDIENCE=
 TMP_PATH=/usr/src/app/tmp
 CLASSIFICATION_BATCH_SIZE=1000
 AGR_CORPUS_DOWNLOAD_DIR=/usr/src/app/alliance_reference_files
+
+COGNITO_ADMIN_CLIENT_ID=
+COGNITO_ADMIN_CLIENT_SECRET=
+COGNITO_TOKEN_URL=
 
 DB_USER=postgres
 DB_NAME=literature
@@ -23,9 +31,15 @@ DB_PASSWORD=
 DB_HOST=postgres
 DB_PORT=5432
 
+PERSISTENT_STORE_DB_USERNAME=
+PERSISTENT_STORE_DB_PASSWORD=
+PERSISTENT_STORE_DB_HOST=
+PERSISTENT_STORE_DB_PORT=
+PERSISTENT_STORE_DB_NAME=
+
 # WormBase Curation Status Page credentials
-WB_USERNAME=your_username_here
-WB_PASSWORD=your_password_here
+WB_USERNAME=
+WB_PASSWORD=
 
 # Entity extraction failure alerts are emailed to the scrum-blueteam-private Slack channel
 # (Slack "send email to channel"). Uses agr_literature_service send_report over Gmail SMTP.

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ htmlcov
 training_sets/*
 stats.txt
 .env.test
+docker-compose.override.yaml
+docker-compose.override.yml
 /tmp/
 /alliance_tei_corpus/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM agr.literature.automated_information_extraction.server-base
+# Deliberately still the legacy base-image name: GoCD builds the base image itself,
+# outside make, and tags it agr_document_classifier_base. The Makefile applies both
+# that tag and agr.literature.automated_information_extraction.server-base to the
+# same image, so this resolves either way. Flip it to the new name only once the
+# GoCD base-image build step has been updated to match.
+FROM agr_document_classifier_base
 
 ENV TZ=UTC
 # Unbuffer stdout so log lines reach the Docker gelf log driver as they are emitted.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM agr_document_classifier_base
+FROM agr.literature.automated_information_extraction.server-base
 
 ENV TZ=UTC
 # Unbuffer stdout so log lines reach the Docker gelf log driver as they are emitted.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM agr_document_classifier_base
 
 ENV TZ=UTC
+# Unbuffer stdout so log lines reach the Docker gelf log driver as they are emitted.
+# Without this, Python block-buffers stdout whenever it is not a TTY (the GoCD
+# `docker run` case) and anything unflushed is lost if the process is killed.
+ENV PYTHONUNBUFFERED=1
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /usr/src/app
 ADD ./requirements.txt .

--- a/Dockerfile_Base
+++ b/Dockerfile_Base
@@ -1,6 +1,8 @@
 FROM python:3.11-slim
 
 ENV TZ=UTC
+# See Dockerfile: keeps logs flowing to the gelf log driver line by line.
+ENV PYTHONUNBUFFERED=1
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /usr/src/app
 ADD ./requirements.txt .

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ endif
 
 include ${ENV_FILE}
 
+# Exported so `make <target> APP_IMAGE=...` reaches docker-compose, which reads it
+# to pick which image to run (prod by default, or the stage image). Empty is fine:
+# compose falls back to its own default.
+export APP_IMAGE
+
 run-local-flake8:
 	python3 -m flake8 .
 
@@ -33,18 +38,27 @@ classify_antibody:
 # The legacy agr_document_classifier / agr_document_classifier_base tags are still
 # applied to the same images so existing GoCD tasks keep working; drop them once
 # every pipeline references the new names.
-# IMAGE_APP_TEST is the stage variant: the same image, tagged a second time in the
-# same build, so stage and prod are guaranteed to be byte-identical.
+# IMAGE_APP_TEST is built INDEPENDENTLY, normally from a feature branch, and runs
+# against the stage/test database via a different env file. It is deliberately a
+# separate build rather than a second tag on the prod image: sharing a build would
+# mean the next prod build silently re-pointed the -test tag at prod code.
 IMAGE_BASE=agr.literature.automated_information_extraction.server-base
 IMAGE_APP=agr.literature.automated_information_extraction.server
 IMAGE_APP_TEST=agr.literature.automated_information_extraction.server-test
 
 doc_classifier_full_build:
 	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base
-	docker build . -t ${IMAGE_APP} -t ${IMAGE_APP_TEST} -t agr_document_classifier
+	docker build . -t ${IMAGE_APP} -t agr_document_classifier
 
 doc_classifier_build:
-	docker build . -t ${IMAGE_APP} -t ${IMAGE_APP_TEST} -t agr_document_classifier
+	docker build . -t ${IMAGE_APP} -t agr_document_classifier
+
+# Stage/test image. GoCD passes --no-cache for reproducibility; omitted here so a
+# local branch build does not reinstall torch every time. Run it with an env file
+# holding the stage DB credentials, e.g.
+#   make classify ENV_FILE=.env.stage APP_IMAGE=${IMAGE_APP_TEST}
+doc_classifier_build_test:
+	docker build . -t ${IMAGE_APP_TEST} -t agr_document_classifier_stage
 
 flybert_build:
 	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,20 @@ extract_entities:
 classify_antibody:
 	GELF_COMPONENT=classify_antibody docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python -m agr_document_classifier.agr_antibody_string_matching_classifier
 
+# Image naming follows the Alliance convention agr.literature.<component>.<role>.
+# The legacy agr_document_classifier / agr_document_classifier_base tags are still
+# applied to the same images so existing GoCD tasks keep working; drop them once
+# every pipeline references the new names.
+IMAGE_BASE=agr.literature.automated_information_extraction.server-base
+IMAGE_APP=agr.literature.automated_information_extraction.server
+
 doc_classifier_full_build:
-	docker build . -f Dockerfile_Base -t agr_document_classifier_base
-	docker build . -t agr_document_classifier
+	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base
+	docker build . -t ${IMAGE_APP} -t agr_document_classifier
 
 doc_classifier_build:
-	docker build . -t agr_document_classifier
+	docker build . -t ${IMAGE_APP} -t agr_document_classifier
 
 flybert_build:
-	docker build . -f Dockerfile_Base -t agr_document_classifier_base
+	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base
 	docker build . -t flybert

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,18 @@ classify_antibody:
 # The legacy agr_document_classifier / agr_document_classifier_base tags are still
 # applied to the same images so existing GoCD tasks keep working; drop them once
 # every pipeline references the new names.
+# IMAGE_APP_TEST is the stage variant: the same image, tagged a second time in the
+# same build, so stage and prod are guaranteed to be byte-identical.
 IMAGE_BASE=agr.literature.automated_information_extraction.server-base
 IMAGE_APP=agr.literature.automated_information_extraction.server
+IMAGE_APP_TEST=agr.literature.automated_information_extraction.server-test
 
 doc_classifier_full_build:
 	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base
-	docker build . -t ${IMAGE_APP} -t agr_document_classifier
+	docker build . -t ${IMAGE_APP} -t ${IMAGE_APP_TEST} -t agr_document_classifier
 
 doc_classifier_build:
-	docker build . -t ${IMAGE_APP} -t agr_document_classifier
+	docker build . -t ${IMAGE_APP} -t ${IMAGE_APP_TEST} -t agr_document_classifier
 
 flybert_build:
 	docker build . -f Dockerfile_Base -t ${IMAGE_BASE} -t agr_document_classifier_base

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,19 @@ run-mypy:
 run-local-mypy:
 	mypy --config-file mypy.config .
 
+# GELF_COMPONENT feeds the gelf log driver's `tag` option in docker-compose.yaml, so
+# each pipeline is identifiable in Graylog as agr.aie.<ENV_STATE>.<component>.
 train:
-	docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_document_classifier.py --mode train --embedding_model_path /data/agr_document_classifier/BioWordVec.vec.bin --datatype_train $(DATATYPE) --mod_train $(MOD)
+	GELF_COMPONENT=train docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_document_classifier.py --mode train --embedding_model_path /data/agr_document_classifier/BioWordVec.vec.bin --datatype_train $(DATATYPE) --mod_train $(MOD)
 
 classify:
-	docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_document_classifier.py --mode classify --embedding_model_path /data/agr_document_classifier/BioWordVec.vec.bin
+	GELF_COMPONENT=classify docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_document_classifier.py --mode classify --embedding_model_path /data/agr_document_classifier/BioWordVec.vec.bin
 
 extract_entities:
-	docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_entity_extractor.py
+	GELF_COMPONENT=extract_entities docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python agr_entity_extractor.py
 
 classify_antibody:
-	docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python -m agr_document_classifier.agr_antibody_string_matching_classifier
+	GELF_COMPONENT=classify_antibody docker-compose --env-file ${ENV_FILE} run agr_automated_information_extraction python -m agr_document_classifier.agr_antibody_string_matching_classifier
 
 doc_classifier_full_build:
 	docker build . -f Dockerfile_Base -t agr_document_classifier_base

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ make, so the tags it applies are configured in the pipeline rather than here.
 ## Logging to Graylog
 
 Container stdout and stderr are shipped to the Alliance Graylog instance at
-`udp://logs.alliancegenome.org:12201` using Docker's built-in `gelf` log driver,
+`udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201`
+using Docker's built-in `gelf` log driver,
 the same mechanism `agr_literature_service` uses. There is no Python-side GELF
 library and no application code involved — anything a pipeline writes to stdout or
 stderr is forwarded by the Docker daemon.
@@ -114,7 +115,7 @@ list):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `GELF_ADDRESS` | `udp://logs.alliancegenome.org:12201` | Where to send GELF packets. |
+| `GELF_ADDRESS` | `udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201` | Where to send GELF packets. |
 | `ENV_STATE` | `dev` | Separates dev / stage / prod streams. Set to `prod` on production hosts. |
 | `GELF_COMPONENT` | `unspecified` | Which pipeline is running. Set per invocation by the Makefile targets. |
 
@@ -135,15 +136,16 @@ itself (see the header comments in `bin/run_export_and_commit.sh` and
 ```sh
 docker run --rm \
   --log-driver gelf \
-  --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+  --log-opt gelf-address=udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201 \
   --log-opt tag=agr.aie.prod.fb_textmining_export \
   ...
 ```
 
 ### Network requirement: the host must be inside the Alliance VPC
 
-`logs.alliancegenome.org` resolves to `172.31.97.52`, an RFC1918 private address in
-the Alliance VPC. **Only hosts inside that network can deliver GELF packets.**
+`agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com` resolves to
+`172.31.96.173`, an RFC1918 private address in the Alliance VPC (it is an
+internal NLB). **Only hosts inside that network can deliver GELF packets.**
 Public DNS resolves the name from anywhere, so resolution succeeding tells you
 nothing about reachability.
 
@@ -155,12 +157,12 @@ This fails silently and is easy to misdiagnose:
   and the messages simply never arrive in Graylog.
 
 Confirmed unreachable from the FlyBase GoCD agent `flysql26` (100% packet loss to
-`172.31.97.52`). Checks, run on the host in question:
+the Graylog input's private address). Checks, run on the host in question:
 
 ```sh
-ip route get 172.31.97.52     # default gateway means no path into the VPC
-ping -c2 172.31.97.52
-traceroute -n -U -p 12201 172.31.97.52
+ip route get 172.31.96.173     # default gateway means no path into the VPC
+ping -c2 172.31.96.173
+traceroute -n -U -p 12201 172.31.96.173
 ```
 
 For hosts outside the VPC, either point `GELF_ADDRESS` at a reachable endpoint or

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Documents for training and classification are fetched from the ABC repository in
 - [Installation](#installation)
 - [Usage](#usage)
 - [Configuration](#configuration)
+- [Running a stage/test image](#running-a-stagetest-image)
 - [Logging to Graylog](#logging-to-graylog)
 - [Development](#development)
 - [License](#license)
@@ -74,6 +75,29 @@ The project uses environment variables for configuration. These variables are de
 - OKTA_*: Configuration for Okta authentication.
 - CLASSIFICATION_BATCH_SIZE: Batch size for document classification.
 - ENV_STATE / GELF_ADDRESS: Centralized logging, see below.
+
+## Running a stage/test image
+
+The stage image is built independently — normally from a feature branch — and runs
+against the stage/test database. It is a separate build, not a retag of the prod
+image, so a later prod build cannot silently replace it.
+
+```sh
+# build it (tags agr.literature.automated_information_extraction.server-test)
+make doc_classifier_build_test
+
+# run it on the same host as prod, pointed at the stage DB via a different env file
+make classify ENV_FILE=.env.stage \
+  APP_IMAGE=agr.literature.automated_information_extraction.server-test
+```
+
+`APP_IMAGE` selects which image the compose service runs and defaults to the prod
+image. Database credentials and every other setting come from `ENV_FILE`, so prod
+and stage can run side by side on one machine without interfering. Set
+`ENV_STATE=stage` in that env file to keep the two apart in Graylog.
+
+Note GoCD builds these images itself with raw `docker build --no-cache`, not via
+make, so the tags it applies are configured in the pipeline rather than here.
 
 ## Logging to Graylog
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Documents for training and classification are fetched from the ABC repository in
 - [Installation](#installation)
 - [Usage](#usage)
 - [Configuration](#configuration)
+- [Logging to Graylog](#logging-to-graylog)
 - [Development](#development)
 - [License](#license)
 
@@ -72,3 +73,65 @@ The project uses environment variables for configuration. These variables are de
 - ABC_API_SERVER: URL for the ABC API server.
 - OKTA_*: Configuration for Okta authentication.
 - CLASSIFICATION_BATCH_SIZE: Batch size for document classification.
+- ENV_STATE / GELF_ADDRESS: Centralized logging, see below.
+
+## Logging to Graylog
+
+Container stdout and stderr are shipped to the Alliance Graylog instance at
+`udp://logs.alliancegenome.org:12201` using Docker's built-in `gelf` log driver,
+the same mechanism `agr_literature_service` uses. There is no Python-side GELF
+library and no application code involved — anything a pipeline writes to stdout or
+stderr is forwarded by the Docker daemon.
+
+The driver is declared in the `logging:` block of `docker-compose.yaml` and is
+controlled by three variables, all consumed by Compose during interpolation rather
+than by the container process (so they must **not** be added to the `environment:`
+list):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `GELF_ADDRESS` | `udp://logs.alliancegenome.org:12201` | Where to send GELF packets. |
+| `ENV_STATE` | `dev` | Separates dev / stage / prod streams. Set to `prod` on production hosts. |
+| `GELF_COMPONENT` | `unspecified` | Which pipeline is running. Set per invocation by the Makefile targets. |
+
+### Finding your run in Graylog
+
+Search on the `tag` field, which is built as `agr.aie.<ENV_STATE>.<GELF_COMPONENT>` —
+for example `tag:agr.aie.prod.classify`. The Docker driver also attaches
+`container_name`, `container_id`, `image_name`, `command` (the exact `python <script>
+--args` line) and `host`, so individual runs remain distinguishable even without a tag.
+
+### Jobs launched outside Compose
+
+The FlyBase textmining jobs run from GoCD as bare `docker run`, which bypasses
+`docker-compose.yaml`. They need the equivalent flags on the `docker run` command
+itself (see the header comments in `bin/run_export_and_commit.sh` and
+`bin/check_textmining_freshness.sh`):
+
+```sh
+docker run --rm \
+  --log-driver gelf \
+  --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+  --log-opt tag=agr.aie.prod.fb_textmining_export \
+  ...
+```
+
+### Caveats
+
+- **`docker logs` no longer works.** With a non-`json-file` driver Docker keeps no
+  local copy. Interactive `docker-compose run` still prints to your terminal, since
+  attach is independent of the log driver, so day-to-day development is unaffected.
+- **The container will not start if the GELF address cannot be resolved.** Docker
+  resolves it at container-create time. To opt out locally, create an uncommitted
+  `docker-compose.override.yaml` (Compose loads it automatically):
+  ```yaml
+  services:
+    agr_automated_information_extraction:
+      logging:
+        driver: json-file
+  ```
+- **Only stdout/stderr is shipped.** Scripts that redirect output to a file (the
+  `crontab` entry, the `.log` files parsed by
+  `scripts/fb_gene_extraction_summarize_run_logs.py`) bypass Graylog entirely.
+- **GELF over UDP is lossy and unordered**, and messages larger than ~8KB are
+  chunked. Do not rely on Graylog for anything that must not be dropped.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,34 @@ docker run --rm \
   ...
 ```
 
+### Network requirement: the host must be inside the Alliance VPC
+
+`logs.alliancegenome.org` resolves to `172.31.97.52`, an RFC1918 private address in
+the Alliance VPC. **Only hosts inside that network can deliver GELF packets.**
+Public DNS resolves the name from anywhere, so resolution succeeding tells you
+nothing about reachability.
+
+This fails silently and is easy to misdiagnose:
+
+- the name resolves, so the container starts and the driver initialises normally;
+- GELF over UDP is fire-and-forget — no connection, no ACK, no error;
+- the job runs to completion and exits 0, output appears on the console as usual,
+  and the messages simply never arrive in Graylog.
+
+Confirmed unreachable from the FlyBase GoCD agent `flysql26` (100% packet loss to
+`172.31.97.52`). Checks, run on the host in question:
+
+```sh
+ip route get 172.31.97.52     # default gateway means no path into the VPC
+ping -c2 172.31.97.52
+traceroute -n -U -p 12201 172.31.97.52
+```
+
+For hosts outside the VPC, either point `GELF_ADDRESS` at a reachable endpoint or
+omit the `--log-driver`/`--log-opt` flags entirely — for those jobs the GoCD console
+remains the log of record. Getting them into Graylog is a networking change
+(a reachable GELF input, or peering/firewall access), not a change to this repo.
+
 ### Caveats
 
 - **`docker logs` no longer works.** With a non-`json-file` driver Docker keeps no

--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -3,8 +3,9 @@
 # If any file's last commit is older than STALE_THRESHOLD_DAYS (default 3),
 # emails curators.
 #
-# Designed to run inside the agr_document_classifier container so it has access
-# to svn 1.14 and to send_report. The cron entry on the GoCD agent should be:
+# Designed to run inside the agr.literature.automated_information_extraction.server
+# container so it has access to svn 1.14 and to send_report. The cron entry on the
+# GoCD agent should be:
 #
 #   30 13 * * * docker run --rm \
 #     --log-driver gelf \
@@ -13,7 +14,7 @@
 #     -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
-#     agr_document_classifier \
+#     agr.literature.automated_information_extraction.server \
 #     ./bin/check_textmining_freshness.sh
 #
 # Required env vars:

--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -7,6 +7,9 @@
 # to svn 1.14 and to send_report. The cron entry on the GoCD agent should be:
 #
 #   30 13 * * * docker run --rm \
+#     --log-driver gelf \
+#     --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+#     --log-opt tag=agr.aie.prod.fb_textmining_freshness \
 #     -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \

--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -17,6 +17,12 @@
 #     agr.literature.automated_information_extraction.server \
 #     ./bin/check_textmining_freshness.sh
 #
+# NOTE: the three gelf options only work from hosts inside the Alliance VPC --
+# logs.alliancegenome.org is 172.31.97.52, an RFC1918 address. The FlyBase GoCD
+# agent (flysql26) has no route to it, so the packets are silently dropped: the
+# container starts fine, the job passes, and nothing reaches Graylog. Omit them
+# there and use the GoCD console. See the README, "Network requirement".
+#
 # Required env vars:
 #   SVN_REPO_URL                                   - parent URL of the
 #                                                    textmining_*.txt files

--- a/bin/check_textmining_freshness.sh
+++ b/bin/check_textmining_freshness.sh
@@ -9,7 +9,7 @@
 #
 #   30 13 * * * docker run --rm \
 #     --log-driver gelf \
-#     --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+#     --log-opt gelf-address=udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201 \
 #     --log-opt tag=agr.aie.prod.fb_textmining_freshness \
 #     -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_USERNAME -e SVN_PASSWORD \
@@ -18,7 +18,7 @@
 #     ./bin/check_textmining_freshness.sh
 #
 # NOTE: the three gelf options only work from hosts inside the Alliance VPC --
-# logs.alliancegenome.org is 172.31.97.52, an RFC1918 address. The FlyBase GoCD
+# the log NLB resolves to 172.31.96.173, an RFC1918 address. The FlyBase GoCD
 # agent (flysql26) has no route to it, so the packets are silently dropped: the
 # container starts fine, the job passes, and nothing reaches Graylog. Omit them
 # there and use the GoCD console. See the README, "Network requirement".

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Self-healing wrapper for the FlyBase ABC textmining export + SVN commit step.
 #
-# This script is intended to run INSIDE the agr_document_classifier container.
+# This script is intended to run INSIDE the
+# agr.literature.automated_information_extraction.server container.
 # The container owns the SVN working copy end-to-end: it checks it out on every
 # run (the WC is ephemeral; no host bind-mount), the export scripts write to it,
 # and the wrapper commits back. SVN auth comes from $SVN_USERNAME / $SVN_PASSWORD
@@ -19,7 +20,7 @@
 #     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \
 #     -e CURATION_STATUS_DIR=/curation_status \
-#     agr_document_classifier \
+#     agr.literature.automated_information_extraction.server \
 #     ./bin/run_export_and_commit.sh
 #
 # CURATION_STATUS_DIR must be /curation_status: the export scripts hardcode

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -14,7 +14,7 @@
 #
 #   docker run --rm \
 #     --log-driver gelf \
-#     --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+#     --log-opt gelf-address=udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201 \
 #     --log-opt tag=agr.aie.prod.fb_textmining_export \
 #     -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_USERNAME -e SVN_PASSWORD \
@@ -24,7 +24,7 @@
 #     ./bin/run_export_and_commit.sh
 #
 # NOTE: the three gelf options only work from hosts inside the Alliance VPC --
-# logs.alliancegenome.org is 172.31.97.52, an RFC1918 address. The FlyBase GoCD
+# the log NLB resolves to 172.31.96.173, an RFC1918 address. The FlyBase GoCD
 # agent (flysql26) has no route to it, so the packets are silently dropped: the
 # container starts fine, the job passes, and nothing reaches Graylog. Omit them
 # there and use the GoCD console. See the README, "Network requirement".

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -12,6 +12,9 @@
 # Example GoCD task:
 #
 #   docker run --rm \
+#     --log-driver gelf \
+#     --log-opt gelf-address=udp://logs.alliancegenome.org:12201 \
+#     --log-opt tag=agr.aie.prod.fb_textmining_export \
 #     -e BLUE_PASSWORD -e CRONTAB_EMAIL -e SENDER_EMAIL -e SENDER_PASSWORD \
 #     -e SVN_USERNAME -e SVN_PASSWORD \
 #     -e SVN_REPO_URL=https://svn.flybase.org/.../curation_status \

--- a/bin/run_export_and_commit.sh
+++ b/bin/run_export_and_commit.sh
@@ -23,6 +23,12 @@
 #     agr.literature.automated_information_extraction.server \
 #     ./bin/run_export_and_commit.sh
 #
+# NOTE: the three gelf options only work from hosts inside the Alliance VPC --
+# logs.alliancegenome.org is 172.31.97.52, an RFC1918 address. The FlyBase GoCD
+# agent (flysql26) has no route to it, so the packets are silently dropped: the
+# container starts fine, the job passes, and nothing reaches Graylog. Omit them
+# there and use the GoCD console. See the README, "Network requirement".
+#
 # CURATION_STATUS_DIR must be /curation_status: the export scripts hardcode
 # /curation_status/textmining_*.txt as their output path.
 #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,10 @@ services:
     build: .
     # Without this Compose derives <project>-<service>; naming it explicitly keeps
     # `docker-compose build/run` in step with the Makefile targets and makes the
-    # _image_name field in Graylog readable.
-    image: agr.literature.automated_information_extraction.server
+    # _image_name field in Graylog readable. Override APP_IMAGE to run the
+    # independently built stage image on the same host, e.g.
+    #   APP_IMAGE=agr.literature.automated_information_extraction.server-test
+    image: ${APP_IMAGE:-agr.literature.automated_information_extraction.server}
     volumes:
       - ${TRAINING_DIR}:/data/agr_document_classifier/training
       - ${CLASSIFICATION_DIR}:/data/agr_document_classifier/to_classify

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,10 @@ version: '3'
 services:
   agr_automated_information_extraction:
     build: .
+    # Without this Compose derives <project>-<service>; naming it explicitly keeps
+    # `docker-compose build/run` in step with the Makefile targets and makes the
+    # _image_name field in Graylog readable.
+    image: agr.literature.automated_information_extraction.server
     volumes:
       - ${TRAINING_DIR}:/data/agr_document_classifier/training
       - ${CLASSIFICATION_DIR}:/data/agr_document_classifier/to_classify

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,3 +31,13 @@ services:
       - SENDER_PASSWORD=${SENDER_PASSWORD}
       - REPLY_TO=${REPLY_TO}
       - SLACK_CHANNEL_EMAIL=${SLACK_CHANNEL_EMAIL}
+    # Ship container stdout/stderr to the Alliance Graylog instance, mirroring the
+    # pattern used by agr_literature_service. GELF_ADDRESS / ENV_STATE / GELF_COMPONENT
+    # are consumed by Compose during interpolation (not by the container process), so
+    # they belong in the env file / invoking shell and NOT in the environment: list
+    # above. GELF_COMPONENT is set per invocation by the Makefile targets.
+    logging:
+      driver: gelf
+      options:
+        gelf-address: '${GELF_ADDRESS:-udp://logs.alliancegenome.org:12201}'
+        tag: 'agr.aie.${ENV_STATE:-dev}.${GELF_COMPONENT:-unspecified}'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,5 +45,5 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: '${GELF_ADDRESS:-udp://logs.alliancegenome.org:12201}'
+        gelf-address: '${GELF_ADDRESS:-udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201}'
         tag: 'agr.aie.${ENV_STATE:-dev}.${GELF_COMPONENT:-unspecified}'


### PR DESCRIPTION
Two related pieces of infrastructure work: centralized logging to Graylog, and adopting the Alliance image-naming convention.

---

# 1. Ship container logs to Graylog

Container stdout/stderr is now forwarded to `udp://agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com:12201` using Docker's built-in `gelf` log driver, mirroring the pattern `agr_literature_service` already uses (commit `63b25537`).

No Python-side GELF library and no application code changes — the existing 14 `logging.basicConfig` call sites all write to stdout or stderr, both of which the driver captures.

### Why the tag differs from agr_literature_service

`agr_literature_service` runs long-lived `docker-compose up` services and uses `container_name` as the Graylog discriminator. This repo runs one-shot `docker-compose run` containers, for which **Compose ignores `container_name`** and generates `<project>-<service>-run-<hash>`. The gelf `tag` option is used instead, built as `agr.aie.<ENV_STATE>.<GELF_COMPONENT>` and set per pipeline by the Makefile.

### Changes

| File | Change |
| --- | --- |
| `docker-compose.yaml` | `logging: driver: gelf` block; address and tag env-configurable, defaulting to the Alliance endpoint |
| `Makefile` | `GELF_COMPONENT` set per target (`train`, `classify`, `extract_entities`, `classify_antibody`) |
| `Dockerfile`, `Dockerfile_Base` | `PYTHONUNBUFFERED=1` so lines reach the driver as emitted rather than in block-buffered chunks lost on kill |
| `bin/*.sh` | equivalent `--log-driver`/`--log-opt` flags added to the documented GoCD `docker run` invocations, which bypass Compose |
| `.env`, `.env.example` | `ENV_STATE`, `GELF_ADDRESS`, plus the previously missing `ENTITY_EXTRACTION_DIR`/`ENTITY_EXTRACTION_PATH`. `.env.example` is new — the README referenced it but it did not exist |
| `README.md` | what is shipped, the env vars, how to find a run in Graylog, and the `docker-compose.override.yaml` opt-out |

### Verification

Tested live against the real `docker-compose.yaml` with a local UDP listener standing in for Graylog. Both messages arrived:

```
"short_message":"INFO:smoke:GELF SMOKE STDOUT"  "level":6  "_tag":"agr.aie.prod.smoketest"
"short_message":"GELF SMOKE STDERR"             "level":3  "_tag":"agr.aie.prod.smoketest"
```

This confirms `docker compose run` **does** honour the service's `logging:` block, that tag interpolation is correct end to end, and that stdout and stderr are both captured with correct syslog levels. Packets also carry `_container_name`, `_container_id`, `_image_name` and `_command` (the full `python …` invocation), so runs stay distinguishable even if `GELF_COMPONENT` is unset.

`docker-compose --env-file .env config` now exits 0; previously it failed with `invalid spec: :/data/agr_entity_extraction/to_extract: empty section between colons`, which was breaking every make target.

---

# 2. Image naming

Adopts `agr.literature.<component>.<role>` for the images this repo builds:

| Old | New |
| --- | --- |
| `agr_document_classifier` | `agr.literature.automated_information_extraction.server` |
| `agr_document_classifier_stage` | `agr.literature.automated_information_extraction.server-test` |
| `agr_document_classifier_base` | `agr.literature.automated_information_extraction.server-base` |

Docker accepts the dotted names — verified by tagging and running one. No registry-hostname misparse, since that only applies when the name contains a `/`.

### Prod and stage are independent builds

The stage image is built separately, normally from a feature branch, and runs against the stage/test database with credentials supplied by a different env file. `make doc_classifier_build_test` is therefore its own target, **not** a second tag on the prod build.

An earlier commit on this branch (`039066a`) got this wrong by tagging both names in one build. That was not just a modelling error but a live hazard: the next prod build would have silently re-pointed `…server-test` at prod code, replacing whatever branch image was under test. Fixed in `4b15b1a` rather than reverted, so the reasoning stays visible in the history.

### Running stage alongside prod

`docker-compose.yaml` now uses `image: ${APP_IMAGE:-…server}`, so both can run on one host:

```sh
make doc_classifier_build_test
make classify ENV_FILE=.env.stage \
  APP_IMAGE=agr.literature.automated_information_extraction.server-test
```

`APP_IMAGE` is exported by the Makefile so command-line overrides reach compose; unset, it falls back to the prod image. Set `ENV_STATE=stage` in that env file to separate the two in Graylog.

### Legacy tags retained

The Makefile still applies `agr_document_classifier`, `agr_document_classifier_stage` and `agr_document_classifier_base` alongside the new names, so nothing breaks on merge. Drop them once every pipeline has moved.

`Dockerfile:1` deliberately still reads `FROM agr_document_classifier_base`. GoCD builds the base image itself under that name; pointing `FROM` at the new name would have broken those builds outright, since the base would not exist locally and Docker would try to pull it from Docker Hub. There is a comment at that line saying when to flip it.

`flybert_build` is unchanged and still produces the `flybert` tag.

---

# ⚠️ Known limitation: GELF only works from inside the Alliance VPC

`agr-log-nlb-prod-2338fbd566b1dd01.elb.us-east-1.amazonaws.com` resolves to **`172.31.96.173`**, an RFC1918 private address in the Alliance VPC — it is an internal NLB. Only hosts inside that network can deliver GELF packets.

This fails **silently**, which makes it easy to misdiagnose:

- public DNS resolves the name from anywhere, so the container starts and the driver initialises normally;
- GELF over UDP is fire-and-forget — no connection, no ACK, no error;
- the job runs to completion, exits 0, output appears on the console as usual, and the messages simply never arrive in Graylog.

**Confirmed unreachable from the FlyBase GoCD agent `flysql26`** (100% packet loss to the Graylog input's private address). A real classify run there produced full console output and zero Graylog messages.

Consequences for rollout:

| Where the job runs | Outcome |
| --- | --- |
| Alliance infrastructure, inside the VPC (the `docker-compose` path) | works — verified end to end |
| FlyBase hosts such as `flysql26` | packets dropped; omit the gelf flags and use the GoCD console |

Nothing in this PR needs changing for it — the configuration is correct, it just cannot deliver from outside the VPC. `GELF_ADDRESS` exists so such a host can be pointed elsewhere, and the `docker-compose.override.yaml` opt-out covers the compose path. Getting FlyBase-hosted jobs into Graylog is a **networking change** (a reachable GELF input, or peering/firewall access), not a code change.

Documented in the README under "Network requirement", and in the header comments of both `bin/*.sh` scripts so the `docker run` examples there aren't taken at face value.

---

# Required follow-up outside this repo

**GoCD builds the images itself with raw `docker build --no-cache`, not via make**, so nothing in this PR changes the tags GoCD applies. The pipeline config needs updating separately:

| GoCD step | Add |
| --- | --- |
| base image build | `-t agr.literature.automated_information_extraction.server-base` |
| prod app build | `-t agr.literature.automated_information_extraction.server` |
| stage app build | `-t agr.literature.automated_information_extraction.server-test` |

Also needed there: the `--log-driver gelf --log-opt gelf-address=… --log-opt tag=…` flags on the FlyBase textmining `docker run` tasks, which bypass Compose entirely. This PR only updates the example commands in the `bin/*.sh` header comments.

Order matters: add the new tags *alongside* the old ones first, and only flip `Dockerfile:1` once the base step emits `…server-base`.

---

# Notes for reviewers

- Only stdout/stderr is shipped. Scripts that redirect to a file (the `crontab` entry, the `.log` files parsed by `scripts/fb_gene_extraction_summarize_run_logs.py`) bypass Graylog. Same limitation exists in `agr_literature_service`.
- `docker logs` no longer works on these containers, since Docker keeps no local copy with a non-`json-file` driver. Interactive `docker-compose run` still prints to the terminal.
- A container will fail to start if the GELF address cannot be resolved. Local opt-out via an uncommitted `docker-compose.override.yaml` is documented in the README and gitignored.
- `utils/ateam_utils.py:19` uses `logging.Logger(__name__)` rather than `logging.getLogger(__name__)`, so that module's records reach no handler and will not appear in Graylog. Left alone deliberately — out of scope, worth a separate ticket.
- The `.env` diff also carries a pre-existing uncommitted `SENDER_EMAIL`/`SENDER_PASSWORD`/`REPLY_TO`/`SLACK_CHANNEL_EMAIL` block (all blank placeholders) that predates this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


