### PR TITLE
fix(docker): unbuffer Python stdout so log lines are emitted as produced

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM agr_document_classifier_base
 
 ENV TZ=UTC
+# Set here as well as in Dockerfile_Base: the base image is built separately by GoCD,
+# so this file cannot assume the base it is built on already carries it.
+ENV PYTHONUNBUFFERED=1
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /usr/src/app
 ADD ./requirements.txt .

--- a/Dockerfile_Base
+++ b/Dockerfile_Base
@@ -1,6 +1,9 @@
 FROM python:3.11-slim
 
 ENV TZ=UTC
+# Unbuffer stdout/stderr so log lines leave the process as they are emitted rather
+# than in block-buffered chunks, which are lost if the container is killed.
+ENV PYTHONUNBUFFERED=1
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /usr/src/app
 ADD ./requirements.txt .


### PR DESCRIPTION
Python block-buffers stdout when it is not a TTY, so container log lines arrive in 4KB clumps and the tail is lost if the container is killed. PYTHONUNBUFFERED=1 makes them leave the process as they are written.

Set in both files: GoCD builds the base image separately, so the application Dockerfile cannot assume its base already carries it.