### PR TITLE
fix(logging): silence nltk.download output at import time

### DIFF
--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -30,9 +30,9 @@ from utils.embedding import load_embedding_model, build_feature_matrix, get_bow_
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
 
-nltk.download('stopwords')
-nltk.download('punkt')
-nltk.download('punkt_tab')
+nltk.download('stopwords', quiet=True)
+nltk.download('punkt', quiet=True)
+nltk.download('punkt_tab', quiet=True)
 
 logger = logging.getLogger(__name__)
 

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 for pkg in ('stopwords', 'punkt', 'punkt_tab'):
     if not nltk.download(pkg, quiet=True):
-        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
+        logger.error('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def configure_logging(log_level):

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -30,11 +30,11 @@ from utils.embedding import load_embedding_model, build_feature_matrix, get_bow_
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
 
-nltk.download('stopwords', quiet=True)
-nltk.download('punkt', quiet=True)
-nltk.download('punkt_tab', quiet=True)
-
 logger = logging.getLogger(__name__)
+
+for pkg in ('stopwords', 'punkt', 'punkt_tab'):
+    if not nltk.download(pkg, quiet=True):
+        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def configure_logging(log_level):

--- a/agr_document_classifier/agr_document_classifier_trainer.py
+++ b/agr_document_classifier/agr_document_classifier_trainer.py
@@ -11,7 +11,6 @@ from typing import List, Union
 
 import utils.thread_limits  # noqa: F401  (import first: pins native threads to 1)
 import joblib
-import nltk
 import numpy as np
 import scipy.sparse as sp
 from gensim.models import KeyedVectors
@@ -30,11 +29,9 @@ from utils.embedding import load_embedding_model, build_feature_matrix, get_bow_
 from utils.date_utils import parse_reference_date
 from utils.get_documents import get_documents, remove_stopwords
 
+# No nltk.download here: importing utils.get_documents above already fetches
+# stopwords/punkt/punkt_tab at import time and reports any failure.
 logger = logging.getLogger(__name__)
-
-for pkg in ('stopwords', 'punkt', 'punkt_tab'):
-    if not nltk.download(pkg, quiet=True):
-        logger.error('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def configure_logging(log_level):

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -43,9 +43,9 @@ from utils.md_utils import AllianceMarkdown
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 from utils.slack_utils import send_slack_notification, format_skipped_jobs_html
 
-nltk.download('stopwords')
-nltk.download('punkt')
-nltk.download('punkt_tab')
+nltk.download('stopwords', quiet=True)
+nltk.download('punkt', quiet=True)
+nltk.download('punkt_tab', quiet=True)
 
 root_data_path = "/data/agr_document_classifier/"
 

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -43,13 +43,13 @@ from utils.md_utils import AllianceMarkdown
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 from utils.slack_utils import send_slack_notification, format_skipped_jobs_html
 
-nltk.download('stopwords', quiet=True)
-nltk.download('punkt', quiet=True)
-nltk.download('punkt_tab', quiet=True)
-
 root_data_path = "/data/agr_document_classifier/"
 
 logger = logging.getLogger(__name__)
+
+for pkg in ('stopwords', 'punkt', 'punkt_tab'):
+    if not nltk.download(pkg, quiet=True):
+        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def configure_logging(log_level):

--- a/agr_document_classifier/agr_priority_classifier_balanced.py
+++ b/agr_document_classifier/agr_priority_classifier_balanced.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 for pkg in ('stopwords', 'punkt', 'punkt_tab'):
     if not nltk.download(pkg, quiet=True):
-        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
+        logger.error('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def configure_logging(log_level):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ attrs==21.4.0
 beautifulsoup4==4.12.3
 cachetools==5.5.2
 certifi==2024.7.4
+# Transitive via PyShEx/PyShExC, which do not constrain it. requests only supports
+# chardet <6 and warns at import when it is newer (RequestsDependencyWarning).
+chardet<6
 charset-normalizer==3.4.1
 click==8.1.7
 cmake==3.31.6

--- a/utils/get_documents.py
+++ b/utils/get_documents.py
@@ -9,12 +9,12 @@ from nltk.corpus import stopwords
 
 from utils.md_utils import AllianceMarkdown
 
-# Download required NLTK data
-nltk.download('stopwords', quiet=True)
-nltk.download('punkt', quiet=True)
-nltk.download('punkt_tab', quiet=True)
-
 logger = logging.getLogger(__name__)
+
+# Download required NLTK data
+for pkg in ('stopwords', 'punkt', 'punkt_tab'):
+    if not nltk.download(pkg, quiet=True):
+        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def get_documents(input_docs_dir: str, include_keywords: bool = False,

--- a/utils/get_documents.py
+++ b/utils/get_documents.py
@@ -10,9 +10,9 @@ from nltk.corpus import stopwords
 from utils.md_utils import AllianceMarkdown
 
 # Download required NLTK data
-nltk.download('stopwords')
-nltk.download('punkt')
-nltk.download('punkt_tab')
+nltk.download('stopwords', quiet=True)
+nltk.download('punkt', quiet=True)
+nltk.download('punkt_tab', quiet=True)
 
 logger = logging.getLogger(__name__)
 

--- a/utils/get_documents.py
+++ b/utils/get_documents.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 # Download required NLTK data
 for pkg in ('stopwords', 'punkt', 'punkt_tab'):
     if not nltk.download(pkg, quiet=True):
-        logger.warning('NLTK download failed for %s; tokenization may fail later', pkg)
+        logger.error('NLTK download failed for %s; tokenization may fail later', pkg)
 
 
 def get_documents(input_docs_dir: str, include_keywords: bool = False,


### PR DESCRIPTION
nltk.download() writes its progress and status lines straight to stderr, which put noise in the GoCD job console on every run. quiet=True keeps the download behaviour identical and suppresses only the reporting.

Covers all three runtime call sites; the Dockerfile downloads are left verbose since that output belongs in the image build log.

In the logs we have:-
2026-08-04 15:17:19.436
ERR
agr.literature.stage.classifier
[nltk_data] Downloading package stopwords to /root/nltk_data...
2026-08-04 15:17:19.446
ERR
agr.literature.stage.classifier
[nltk_data] Package stopwords is already up-to-date!
2026-08-04 15:17:19.446
ERR
agr.literature.stage.classifier
[nltk_data] Downloading package punkt to /root/nltk_data...
2026-08-04 15:17:19.471
ERR
agr.literature.stage.classifier
[nltk_data] Package punkt is already up-to-date!
2026-08-04 15:17:19.482
ERR
agr.literature.stage.classifier
[nltk_data] Downloading package punkt_tab to /root/nltk_data...
2026-08-04 15:17:19.493
ERR
agr.literature.stage.classifier
[nltk_data] Package punkt_tab is already up-to-date!

So not a error but if we want to monitor the logs then removing this will make it easier.